### PR TITLE
Ook 'admlezers' de NAW-gegevens van users laten zien

### DIFF
--- a/kn/leden/templates/leden/user_detail.html
+++ b/kn/leden/templates/leden/user_detail.html
@@ -50,11 +50,11 @@
                 >{{ s.study.humanName }}</a>
         op <a href="{{ s.institute.get_absolute_url }}"
                 >{{ s.institute.humanName}}</a>
-        {% if "secretariaat" in user.cached_groups_names %}
+        {% if "secretariaat" in user.cached_groups_names or "admlezers" in user.cached_groups_names %}
         {% if s.number %}
         studentnummer {{ s.number }}
         {% endif %}
-        {% endif %}{# "secretariaat" in user.cached_groups_names #}
+        {% endif %}{# "secretariaat" in user.cached_groups_names or "admlezers" in user.cached_groups_names #}
         {% if s.from or s.until %}
         ({% if s.from %}
         van {{ s.from.date }}
@@ -89,8 +89,8 @@
         </ul>
         </dd>
         {% endif %}{# object.telephones #}
-        {% endif %}{# "secretariaat" in user.cached_groups_names #}
-        {% if "secretariaat" in user.cached_groups_names %}
+        {% endif %}{# "secretariaat" in user.cached_groups_names or "admlezers" in user.cached_groups_names #}
+        {% if "secretariaat" in user.cached_groups_names or "admlezers" in user.cached_groups_names %}
 	{% if object.addresses %}
 	<dt>Adres</dt>
         <dd>


### PR DESCRIPTION
Willen we de groep admlezers dit recht geven?

Het doel is (in dit geval) het bestuur ook inzage te geven in deze gegevens.
