### PR TITLE
Tel het aantal leden van een groep

### DIFF
--- a/kn/base/templatetags/base.py
+++ b/kn/base/templatetags/base.py
@@ -20,4 +20,9 @@ def email_filter(value):
 def mark_safe_filter(value):
     return mark_safe(value)
 
+# http://ianrolfe.livejournal.com/37243.html
+@register.filter(name='lookup')
+def lookup_filter(dict, index):
+    return dict.get(index, '')
+
 # vim: et:sta:bs=2:sw=4:

--- a/kn/leden/entities.py
+++ b/kn/leden/entities.py
@@ -564,6 +564,7 @@ class Entity(SONWrapper):
                     str(n) for n in g.names])
         return self._groups_names_cache
 
+    # get reverse-related
     def get_rrelated(self, how=-1, _from=None, until=None, deref_who=True,
                 deref_with=True, deref_how=True):
         return query_relations(-1, self, how, _from, until, deref_who,

--- a/kn/leden/templates/leden/entity_base.html
+++ b/kn/leden/templates/leden/entity_base.html
@@ -1,5 +1,6 @@
 {% extends "leden/base.html" %}
 {% load leden %}
+{% load base %}
 
 {% block body %}
 

--- a/kn/leden/templatetags/leden.py
+++ b/kn/leden/templatetags/leden.py
@@ -19,11 +19,4 @@ def rel_when_filter(r):
         ret += 'tot %s' % until.date()
     return '(%s)' % ret
 
-# http://ianrolfe.livejournal.com/37243.html
-@register.filter(name='lookup')
-def lookup_filter(dict, index):
-    if index in dict:
-        return dict[index]
-    return ''
-
 # vim: et:sta:bs=2:sw=4:

--- a/kn/leden/views.py
+++ b/kn/leden/views.py
@@ -103,9 +103,12 @@ def _entity_detail(request, e):
     year_counts = {}
     for r in rrelated:
         key = r['until_year']
-        if key == None:
+        if key is None:
             key = 'this'
-        year_counts[key] = year_counts.get(key, 0) + 1
+
+        if not key in year_counts:
+            year_counts[key] = 0
+        year_counts[key] += 1
 
     ctx = {'related': related,
            'rrelated': rrelated,


### PR DESCRIPTION
Dit geeft het aantal huidige leden in een groep en voor elk jaar hoeveel er tot dat jaar lid waren van die groep. Bijvoorbeeld de groep [leden](https://karpenoktem.nl/smoelen/naamdrager/leden/).

Het is vergelijkbaar met de lijst van aanmeldingen bij een activiteit.

Het was nogal onhandig om het op dezelfde manier te doen als dat het nu is. Om het beter te doen, zou heel `rrelated` (geen idee wat dat precies is, de naam zegt me niet veel) opgesplitst moeten worden per jaar. Daarmee zou het hele zaakje wat netter worden maar voor mij is dat allemaal een beetje zwarte magie daar, dus ik blijf er liever van af tot ik het snap.
