### PR TITLE
Prevent Nivo Slider bug in Internet Explorer

### DIFF
--- a/kn/static/media/style/home.css
+++ b/kn/static/media/style/home.css
@@ -52,3 +52,8 @@
 	background-color: transparent !important;
 	margin: 0 !important;
 }
+/* This prevents strange resizes in Internet Explorer
+ * See http://stackoverflow.com/a/15073788 */
+.nivo-main-image {
+	height: auto;
+}


### PR DESCRIPTION
Er zat een bug in Nivo Slider / Internet Explorer waardoor de afbeeldingen in de hoogte werden uitgerekt tijdens het laden. Dit verhelpt die bug.

http://stackoverflow.com/questions/14872634/nivo-slider-first-image-is-scaled-unproportional-when-displayed-the-first-time/15073788#comment21219829_15073788
