### PR TITLE
Planning layout

### DIFF
--- a/kn/planning/templates/planning/overview.html
+++ b/kn/planning/templates/planning/overview.html
@@ -5,7 +5,7 @@
 {{ block.super }}
 <style type="text/css">
 #planningOverview-wrapper {
-    overflow-x: scroll;
+    overflow-x: auto;
 }
 #planningOverview {
     width: 100%;


### PR DESCRIPTION
Gebruik de hele breedte op desktop schermen en zorg ervoor dat de tabel gescrolld kan worden op kleine schermen (dan scrollt alleen de tabel, en niet de hele pagina).

Fix voor #192.
