### PR TITLE
Use `utf-8` instead of `utf8`. This fixes a problem with IE9

### DIFF
--- a/kn/base/http.py
+++ b/kn/base/http.py
@@ -11,7 +11,7 @@ def redirect_to_referer(request):
 class JsonHttpResponse(HttpResponse):
     def __init__(self, obj, *args, **kwargs):
         if 'mimetype' not in kwargs:
-            kwargs['mimetype'] = 'application/json; charset=utf8'
+            kwargs['mimetype'] = 'application/json; charset=utf-8'
         super(JsonHttpResponse, self).__init__(
             json.dumps(obj), *args, **kwargs)
 


### PR DESCRIPTION
Zie https://github.com/karpenoktem/kninfra/pull/203#issuecomment-54372102

Nu wordt de entity selector ook in IE8 en IE9 gebruikt. Ik heb het voor de zekerheid ook in een paar andere browsers getest.
