### PR TITLE
load Google Analytics asynchronously

### DIFF
--- a/kn/base/templates/base/bare.html
+++ b/kn/base/templates/base/bare.html
@@ -19,6 +19,20 @@
 		<link href="{% url style-bare %}"
 			rel="stylesheet" type="text/css" />
 		<link rel="icon" href="{{ MEDIA_URL }}/base/favicon.ico" />
+		<script type="text/javascript">
+		  var _gaq = _gaq || [];
+		  _gaq.push(['_setAccount', 'UA-11922614-1']);
+		  _gaq.push(['_trackPageview']);
+
+		  (function() {
+		    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+		    ga.src = 'https://ssl.google-analytics.com/ga.js';
+		    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+		  })();
+
+		  var csrf_token = "{{ csrf_token }}";
+		  var leden_api_url = "{% url leden-api %}";
+		</script>
 		{% endblock %}
 	</head>
         <body>
@@ -44,17 +58,5 @@
                         </div>
                 </div>
                 {% endblock footer %}
-	<script type="text/javascript">
-		var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-		document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-	</script>
-	<script type="text/javascript">
-	try {
-	var pageTracker = _gat._getTracker("UA-11922614-1");
-	pageTracker._trackPageview();
-        } catch(err) {}
-        var csrf_token = "{{ csrf_token }}";
-        var leden_api_url = "{% url leden-api %}";
-        </script>
 	</body>	
 </html>


### PR DESCRIPTION
We zouden een andere tracker gebruiken dan Google Analytics, maar zolang dat nog niet gebeurd is, een kleine potentiele snelheidsverbetering.

https://developers.google.com/analytics/devguides/collection/gajs/asyncTracking

Ik heb de code een beetje aangepast: nu wordt altijd de SSL versie geladen aangezien de KN site toch altijd HTTPS gebruikt.
