### PR TITLE
Laadt jquery.cookie.js asynchroon

### DIFF
--- a/kn/base/media/common.js
+++ b/kn/base/media/common.js
@@ -141,23 +141,6 @@ $(document).ready(function() {
         fixHeader();
     }
 
-    $('#csrfmiddlewaretoken').val(getCsrftoken());
-
-    $(document.getElementById('loginButtonLink')).bind('click', function (event) {
-        var loginButton = $('#loginButton');
-        loginButton.toggleClass('open');
-        event.preventDefault();
-        event.stopPropagation();
-    });
-
-    $(document.body).bind('click', function (event) {
-        $('#loginButton').removeClass('open');
-    });
-
-    $('#loginWindow').bind('click', function (event) {
-        event.stopPropagation();
-    });
-
     $('#submenu-button').bind('click', function(event) {
         event.preventDefault();
         $('#submenu-wrapper').toggleClass('open');
@@ -173,6 +156,27 @@ function rot13 (s) {
         return String.fromCharCode(k + (c ? 96 : 64));
     }
     ).join('');
+}
+
+function setupLoginWindow() {
+    $(document).ready(function() {
+        $('#csrfmiddlewaretoken').val(getCsrftoken());
+
+        $(document.getElementById('loginButtonLink')).bind('click', function (event) {
+            var loginButton = $('#loginButton');
+            loginButton.toggleClass('open');
+            event.preventDefault();
+            event.stopPropagation();
+        });
+
+        $(document.body).bind('click', function (event) {
+            $('#loginButton').removeClass('open');
+        });
+
+        $('#loginWindow').bind('click', function (event) {
+            event.stopPropagation();
+        });
+    });
 }
 
 function unobfuscateEmail() {

--- a/kn/base/templates/base/bare.html
+++ b/kn/base/templates/base/bare.html
@@ -12,10 +12,11 @@
                 <script type="text/javascript"
                         src="{{ MEDIA_URL }}/base/jquery-ui-1.8.22/the.js">
                 </script>
-                <script type="text/javascript"
-                        src="{{ MEDIA_URL }}/base/jquery.cookie.js"></script>
 		<script type="text/javascript"
 			src="{{ MEDIA_URL }}/base/common.js"></script>
+                <script type="text/javascript"
+		    src="{{ MEDIA_URL }}/base/jquery.cookie.js" async
+		    onload="setupLoginWindow();"></script>
 		<link href="{% url style-bare %}"
 			rel="stylesheet" type="text/css" />
 		<link rel="icon" href="{{ MEDIA_URL }}/base/favicon.ico" />


### PR DESCRIPTION
Dit zorgt ervoor dat één JavaScript request minder gedaan hoeft te worden voordat de pagina gerenderd kan worden in browsers die [`async`](http://caniuse.com/#feat=script-async) ondersteunen. In andere browsers is er geen snelheidsverbetering.

Helaas werkt dit niet in IE8, maar in IE8 blijft de "leden" link simpelweg een link naar de loginpagina, zonder fancy popup. Het werkt wel in IE9+ en alle andere browsers die ik heb getest.
