### PR TITLE
Always include styles before scripts

### DIFF
--- a/kn/agenda/templates/agenda/agenda.html
+++ b/kn/agenda/templates/agenda/agenda.html
@@ -1,10 +1,10 @@
 {% extends "static/base.html" %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link rel="stylesheet"
   href="{% url style-agenda %}" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 <div>

--- a/kn/base/templates/base/bare.html
+++ b/kn/base/templates/base/bare.html
@@ -5,10 +5,14 @@
 		{% block head %}
 		<title>{% block title %}ASV Karpe Noktem{% endblock %}</title>
 		<meta name="viewport" content="width=device-width"/>
+		{% block styles %}
+		<link rel="stylesheet" type="text/css"
+			href="{{ MEDIA_URL }}/base/jquery-ui-1.8.22/the.css" />
+		<link href="{% url style-bare %}"
+			rel="stylesheet" type="text/css" />
+		{% endblock styles %}
 		<script type="text/javascript"
-                       src="{{ MEDIA_URL }}/base/jquery-1.11.1.min.js"></script>
-                <link rel="stylesheet" type="text/css"
-                        href="{{ MEDIA_URL }}/base/jquery-ui-1.8.22/the.css" />
+                        src="{{ MEDIA_URL }}/base/jquery-1.11.1.min.js"></script>
                 <script type="text/javascript"
                         src="{{ MEDIA_URL }}/base/jquery-ui-1.8.22/the.js">
                 </script>
@@ -16,8 +20,6 @@
                         src="{{ MEDIA_URL }}/base/jquery.cookie.js"></script>
 		<script type="text/javascript"
 			src="{{ MEDIA_URL }}/base/common.js"></script>
-		<link href="{% url style-bare %}"
-			rel="stylesheet" type="text/css" />
 		<link rel="icon" href="{{ MEDIA_URL }}/base/favicon.ico" />
 		<script type="text/javascript">
 		  var _gaq = _gaq || [];

--- a/kn/base/templates/base/base.html
+++ b/kn/base/templates/base/base.html
@@ -2,11 +2,11 @@
 
 {% load base %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link href="{% url style-base %}"
 	rel="stylesheet" type="text/css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block header %}
 {{ block.super }}

--- a/kn/leden/templates/leden/user_detail.html
+++ b/kn/leden/templates/leden/user_detail.html
@@ -2,11 +2,11 @@
 {% load base %}
 <!-- TODO stub -->
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link href="{{ MEDIA_URL }}/leden/user_detail.css"
 	rel="stylesheet" type="text/css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 {% if hasPhoto %}

--- a/kn/planning/templates/planning/overview.html
+++ b/kn/planning/templates/planning/overview.html
@@ -1,7 +1,7 @@
 {% extends "leden/base.html" %}
 {% load base %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <style type="text/css">
 #planningOverview-wrapper {
@@ -16,7 +16,7 @@
     text-align: center;
 }
 </style>
-{% endblock head %}
+{% endblock styles %}
 
 {% block body %}
 <div id="planningOverview-wrapper">

--- a/kn/reglementen/templates/reglementen/version_detail.html
+++ b/kn/reglementen/templates/reglementen/version_detail.html
@@ -1,11 +1,11 @@
 {% extends "base/base.html" %}
 {% load base %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link href="{{ MEDIA_URL }}/reglementen/regl.css"
 	rel="stylesheet" type="text/css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 <h1>{{ version.reglement.humanName }}</h1>

--- a/kn/static/templates/static/aktanokturna.html
+++ b/kn/static/templates/static/aktanokturna.html
@@ -1,10 +1,10 @@
 {% extends "static/overbase.html" %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link rel="stylesheet"
   href="{{ MEDIA_URL }}/static/style/aktanokturna.css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 <p>Hier kun je de oudere uitgaven van de Akta Nokturna downloaden:</p>

--- a/kn/static/templates/static/home.html
+++ b/kn/static/templates/static/home.html
@@ -1,12 +1,16 @@
 {% extends "static/base.html" %}
 {% load short_agenda %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link rel="stylesheet"
   href="{% url style-agenda %}" />
 <link rel="stylesheet"
   href="{{ MEDIA_URL }}/static/style/home.css" />
+{% endblock styles %}
+
+{% block head %}
+{{ block.super }}
 <script type="text/javascript"
   src="{{ MEDIA_URL }}/static/jquery.nivo.slider.pack.js"></script>
 <link rel="stylesheet" type="text/css" href="{{ MEDIA_URL }}/static/style/nivo-slider.css" />

--- a/kn/static/templates/static/intro2009.html
+++ b/kn/static/templates/static/intro2009.html
@@ -2,10 +2,10 @@
 
 {% load base %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link rel="stylesheet" href="{{ MEDIA_URL }}/static/style/intro2009.css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 <dl id="introAgenda">

--- a/kn/static/templates/static/intro2010.html
+++ b/kn/static/templates/static/intro2010.html
@@ -2,10 +2,10 @@
 
 {% load base %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link rel="stylesheet" href="{{ MEDIA_URL }}/static/style/intro2010.css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 <dl id="introAgenda">

--- a/kn/static/templates/static/introPoster2009.html
+++ b/kn/static/templates/static/introPoster2009.html
@@ -1,10 +1,10 @@
 {% extends "base/bare.html" %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link rel="stylesheet"
   href="{{ MEDIA_URL }}/static/style/introPoster2009.css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 <a href="{% url intro2009 %}" title="Naar de website" />

--- a/kn/static/templates/static/introPoster2010.html
+++ b/kn/static/templates/static/introPoster2010.html
@@ -1,10 +1,10 @@
 {% extends "base/bare.html" %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link rel="stylesheet"
   href="{{ MEDIA_URL }}/static/style/introPoster2010.css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 <a href="{% url intro2010 %}" title="Naar de website" />

--- a/kn/static/templates/static/introPoster2011.html
+++ b/kn/static/templates/static/introPoster2011.html
@@ -1,10 +1,10 @@
 {% extends "base/bare.html" %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link rel="stylesheet"
   href="{{ MEDIA_URL }}/static/style/introPoster2011.css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 <a href="{% url home %}" title="Naar de website" />

--- a/kn/static/templates/static/introPoster2012.html
+++ b/kn/static/templates/static/introPoster2012.html
@@ -1,10 +1,10 @@
 {% extends "base/bare.html" %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link rel="stylesheet"
   href="{{ MEDIA_URL }}/static/style/introPoster2012.css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 <a href="{% url home %}" title="Naar de website" />

--- a/kn/static/templates/static/introPoster2013.html
+++ b/kn/static/templates/static/introPoster2013.html
@@ -1,10 +1,10 @@
 {% extends "base/bare.html" %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link rel="stylesheet"
   href="{{ MEDIA_URL }}/static/style/introPoster2013.css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 <a href="{% url home %}" title="Naar de website" />

--- a/kn/static/templates/static/introPoster2014.html
+++ b/kn/static/templates/static/introPoster2014.html
@@ -1,10 +1,10 @@
 {% extends "base/bare.html" %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link rel="stylesheet"
   href="{{ MEDIA_URL }}/static/style/introPoster2014.css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 <a href="{% url home %}" title="Naar de website" />

--- a/kn/static/templates/static/lustrum.html
+++ b/kn/static/templates/static/lustrum.html
@@ -1,9 +1,9 @@
 {% extends "static/base.html" %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link rel="stylesheet" href="{{ MEDIA_URL }}/static/style/lustrum.css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 <dl id="lustrumAgenda">

--- a/kn/static/templates/static/lustrumPoster10.html
+++ b/kn/static/templates/static/lustrumPoster10.html
@@ -1,10 +1,10 @@
 {% extends "base/bare.html" %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link rel="stylesheet"
   href="{{ MEDIA_URL }}/static/style/lustrumPoster10.css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 <a href="{% url lustrum %}" title="Naar de website" />

--- a/kn/static/templates/static/lustrumPoster5.html
+++ b/kn/static/templates/static/lustrumPoster5.html
@@ -1,10 +1,10 @@
 {% extends "base/bare.html" %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link rel="stylesheet"
   href="{{ MEDIA_URL }}/static/style/lustrumPoster5.css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 <a href="{% url lustrum %}" title="Naar de website" />

--- a/kn/static/templates/static/openweekPoster2013.html
+++ b/kn/static/templates/static/openweekPoster2013.html
@@ -1,10 +1,10 @@
 {% extends "base/bare.html" %}
 
-{% block head %}
+{% block styles %}
 {{ block.super }}
 <link rel="stylesheet"
   href="{{ MEDIA_URL }}/static/style/openweekPoster2013.css" />
-{% endblock %}
+{% endblock styles %}
 
 {% block body %}
 <a href="{% url home %}" title="Naar de website" />


### PR DESCRIPTION
This is needed for two reasons:
1. common.js depends on the CSS being loaded. But $(document).ready does not
   guarantee that all CSS is actually loaded. So all stylesheets needs to be
   included before common.js.
   See http://api.jquery.com/ready/
2. It is a best practice for speed to put stylesheets before scripts. It isn't
   really relevant nowadays, but in the past, browsers used to wait for scripts
   to execute before stylesheets even started to load.
   http://www.feedthebot.com/pagespeed/style-script-order.html
   (There used to be a PageSpeed Insights rule for this, but it's gone.)
