### PR TITLE
Let openweekPoster2013 use the same style as other recent posters

### DIFF
--- a/kn/static/media/style/openweekPoster2013.css
+++ b/kn/static/media/style/openweekPoster2013.css
@@ -1,18 +1,1 @@
-.boilerplate {
-	border: none;	
-	margin-left: -80px;
-}
-
-.wrappingtext {
-	font-size: small;
-	text-align: center;
-}
-
-.wrappingtext,
-.wrappingtext a {
-	color: gray;
-}
-
-.wrappingtext a:hover {
-	color: white;
-}
+introPoster2009.css


### PR DESCRIPTION
Dit zorgt ervoor dat een gekke witte rand verdwijnt en dat de horizontale scrollbar (?) verdwijnt.
(De horizontale scrollbar kwam door de `margin-left: -80px`).

Niet meer echt nodig maar wel leuk :)
