### PR TITLE
Use the Django URL name for the home link

### DIFF
--- a/kn/base/templates/base/base.html
+++ b/kn/base/templates/base/base.html
@@ -12,7 +12,7 @@
 {{ block.super }}
 <div id="header">
         <div class="container">
-                <a href="/" id="logo">
+                <a href="{% url home %}" id="logo">
                         <img width="310" src="{{ MEDIA_URL }}/base/logo.png"
                                 alt="Karpe Noktem" />
                 </a>


### PR DESCRIPTION
This also fixes a small issue with posters: clicking the logo would return to the poster, and not go to the homepage.
