### PR TITLE
Verwijder `max-width: 94%` voor `img`

### DIFF
--- a/kn/base/templates/base/base.css
+++ b/kn/base/templates/base/base.css
@@ -213,7 +213,6 @@ body {
 	background-color: #f8f8f8;
 	box-shadow: 0px 0px 2px #a31e1b;
 	margin: 0.25em 0.5em;
-	max-width: 94%;
 }
 #content .nivoSlider img {
 	max-width: none; /* initial */


### PR DESCRIPTION
In de mobiele versie patches van @aykevl93 staat een CSS regel die ervoor zorgt dat bijna overal de plaatjes een `max-width: 94%` krijgen.  Dat lijkt mij in geen geval de bedoeling: je krijgt lelijke schaal artefacten. 

@aykevl93 
