### PR TITLE
Activiteiten notificaties in een enkele thread

### DIFF
--- a/kn/base/mail.py
+++ b/kn/base/mail.py
@@ -5,7 +5,7 @@ import django.core.mail
 from kn import settings
 
 def render_then_email(template_name, to, ctx={}, cc=[], bcc=[], from_email=None,
-                        reply_to=None):
+                        reply_to=None, headers=None):
     """ Render an e-mail from a template and send it. """
     # Normalize arguments
     if isinstance(to, basestring):
@@ -14,6 +14,8 @@ def render_then_email(template_name, to, ctx={}, cc=[], bcc=[], from_email=None,
         cc = [cc]
     if isinstance(bcc, basestring):
         bcc = [bcc]
+    if headers is None:
+        headers = {}
     # Render template
     template = django.template.loader.get_template(template_name)
     rendered_nodes = {}
@@ -31,7 +33,6 @@ def render_then_email(template_name, to, ctx={}, cc=[], bcc=[], from_email=None,
         raise KeyError, "Missing plain block"
 
     # Set up e-mail
-    headers = {}
     if cc:
         headers['CC'] = ', '.join(cc)
     if reply_to:

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -2,6 +2,7 @@ import decimal
 
 from django.db.models import permalink
 from django.utils.html import escape, linebreaks
+from django.core.mail import EmailMessage
 
 from kn.leden.mongo import db, SONWrapper, _id, son_property, ObjectId
 import kn.leden.entities as Es
@@ -141,5 +142,21 @@ class Subscription(SONWrapper):
     confirmed = son_property(('confirmed',), True)
     subscribedBy_notes = son_property(('subscribedBy_notes',))
     dateConfirmed = son_property(('dateConfirmed',))
+
+    def send_notification(self, subject, body):
+        cc = [self.event._data.owner.canonical_full_email]
+        if self.subscribedBy:
+            cc.append(self.subscribedBy.canonical_full_email)
+        email = EmailMessage(
+                subject,
+                body,
+                'Karpe Noktem Activiteiten <root@karpenoktem.nl>',
+                [self.user.canonical_full_email],
+                cc=cc,
+                headers={
+                    'Reply-To': self.event._data.owner.canonical_full_email
+                },
+        )
+        email.send()
 
 # vim: et:sta:bs=2:sw=4:

--- a/kn/subscriptions/views.py
+++ b/kn/subscriptions/views.py
@@ -7,7 +7,6 @@ from django.template import RequestContext
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import Group
 from django.http import Http404, HttpResponseRedirect
-from django.core.mail import EmailMessage
 from django.core.exceptions import PermissionDenied
 
 from kn.base.mail import render_then_email
@@ -80,7 +79,7 @@ def event_detail(request, name):
                 'confirmed': False,
                 'subscribedBy': _id(request.user)})
             other_subscription.save()
-            email = EmailMessage(
+            other_subscription.send_notification(
                     "Bevestig je aanmelding voor %s" % event.humanName,
                      event.subscribedByOtherMailBody % {
                         'firstName': user.first_name,
@@ -89,16 +88,7 @@ def event_detail(request, name):
                         'eventName': event.humanName,
                         'confirmationLink': ("http://karpenoktem.nl%s" %
                                 reverse('event-detail', args=(event.name,))),
-                        'owner': event.owner.humanName},
-                    'Karpe Noktem Activiteiten <root@karpenoktem.nl>',
-                    [user.canonical_full_email],
-                    [event.owner.canonical_full_email,
-                     request.user.canonical_full_email],
-                    headers={
-                        'Cc': '%s, %s' % (event.owner.canonical_full_email,
-                                        request.user.canonical_full_email),
-                        'Reply-To': event.owner.canonical_full_email})
-            email.send()
+                        'owner': event.owner.humanName})
     if (subscription is None and request.method == 'POST'
             and event.is_open and ('who' not in request.POST
                 or request.POST['who'] == str(request.user.id))):
@@ -110,20 +100,13 @@ def event_detail(request, name):
             'date': datetime.datetime.now(),
             'debit': str(event.cost)})
         subscription.save()
-        email = EmailMessage(
+        subscription.send_notification(
                 "Aanmelding %s" % event.humanName,
                  event.mailBody % {
                     'firstName': request.user.first_name,
                     'eventName': event.humanName,
                     'owner': event.owner.humanName,
-                    'notes': notes},
-                'Karpe Noktem Activiteiten <root@karpenoktem.nl>',
-                [request.user.canonical_full_email],
-                [event.owner.canonical_full_email],
-                headers={
-                    'Cc': event.owner.canonical_full_email,
-                    'Reply-To': event.owner.canonical_full_email})
-        email.send()
+                    'notes': notes})
     subscrlist = tuple(event.get_subscriptions())
     ctx = {'object': event,
            'user': request.user,

--- a/kn/subscriptions/views.py
+++ b/kn/subscriptions/views.py
@@ -259,7 +259,12 @@ def event_new_or_edit(request, edit=None):
                     ('event-edited' if edit else 'new-event') + '.mail.txt',
                     Es.by_name('secretariaat').canonical_full_email, {
                         'event': e,
-                        'user': request.user})
+                        'user': request.user},
+                    headers={
+                        'In-Reply-To': e.messageId,
+                        'References': e.messageId,
+                    },
+            )
             return HttpResponseRedirect(reverse('event-detail', args=(e.name,)))
     elif edit is None:
         form = AddEventForm()


### PR DESCRIPTION
Dit voegt de juiste headers toe dat bijvoorbeeld Gmail de juiste mails in een enkele conversatie plaatst (en niet maar wat gaat gokken). Zie issue #230.

Ik heb het niet volledig kunnen testen omdat mails verzenden toch wat lastig gaat, maar de rauwe tekst die hij produceert lijkt in orde:

```
Content-Type: text/plain; charset="utf-8"
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit
Subject: Aanmelding Test 8
From: Karpe Noktem Activiteiten <root@karpenoktem.nl>
To: Ayke Bladiebla <ayke@ld.kn.cx>
Cc: Webcie <webcie@ld.kn.cx>
Date: Thu, 11 Dec 2014 19:39:17 -0000
Message-ID: <20141211193917.14449.33378@localhost>
Reply-To: Webcie <webcie@ld.kn.cx>
References: <activiteit/webcie-test8@ld.kn.cx>
In-Reply-To: <activiteit/webcie-test8@ld.kn.cx>

Hallo Ayke,

Je hebt je aangemeld voor Test 8.

Je opmerkingen waren:


Met een vriendelijke groet,

Webcie
```