### PR TITLE
Fix voor #244

### DIFF
--- a/kn/subscriptions/templates/subscriptions/event_new_or_edit.html
+++ b/kn/subscriptions/templates/subscriptions/event_new_or_edit.html
@@ -1,7 +1,7 @@
 {% extends "leden/base.html" %}
 {% load base %}
 {% block body %}
-{% if form.name.value %}
+{% if edit %}
 <h1>Bewerk activiteit {{ form.humanName.value }}</h1>
 {% else %}
 <h1>Nieuwe activiteit</h1>
@@ -9,7 +9,7 @@
 <form method="post" action="?" class="top-aligned">
         {% csrf_token %}
         {{ form.as_p }}
-        {% if form.name.value %}
+        {% if edit %}
         <input type="submit" value="Pas aan!"/>
         {% else %}
         <input type="submit" value="Maak aan!"/>

--- a/kn/subscriptions/views.py
+++ b/kn/subscriptions/views.py
@@ -283,7 +283,8 @@ def event_new_or_edit(request, edit=None):
     else:
         d = e._data
         form = AddEventForm(d)
-    ctx = {'form': form}
+    ctx = {'form': form,
+           'edit': edit}
     return render_to_response('subscriptions/event_new_or_edit.html', ctx,
             context_instance=RequestContext(request))
 


### PR DESCRIPTION
Als je iets invulde in 'korte naam', de rest leeg liet en op 'Maak aan!' drukte, leek het of de activiteit al aangemaakt was. Dan stond er weer 'Bewerk activiteit' en dergelijke. Deze commit fixt dat.
