### PR TITLE
[WIP] vagrant & salt

### DIFF
--- a/salt/states/common/adminutils.sls
+++ b/salt/states/common/adminutils.sls
@@ -13,6 +13,9 @@ ncdu:
 vim:
     pkg:
         - installed
+ipython:
+    pkg:
+        - installed
 /etc/vim/vimrc.local:
     file.managed:
         - source: salt://common/vimrc


### PR DESCRIPTION
Het idee?   Installeer [vagrant](https://www.vagrantup.com); clone de `kninfra` repo en tik daarna louter

     $ vagrant up
     # ....
     $ vagrant ssh

En heb een shell in een volledig klaargemaakte virtualmachine met sankhara en phassa.  In de achtergrond gebruiken we [salt](http://www.saltstack.com) voor het inrichten.

(In ieder geval) nog te doen:

- [ ] smoelenboek draaiend krijgen
- [ ] giedo
- [ ] daan
- [ ] cilia
- [ ] postfix
- [ ] mailman
- [ ] fotoboek
- [ ] cron
- [ ] wolk
- [ ] wiki
- [ ] forum
- [ ] ldap
- [ ] freeradius
- [ ] smtp
- [ ] ssl
- [ ] suphp op phassa
- [ ] nginx op phassa
- [ ] alle oude rewrites van lighttpd
- [ ] ...
- [ ] khandhas overzetten op salt
- [ ] sankhara & phassa overzetten op salt
- [ ] locale probleem fixen