### PR TITLE
ZEUS agenda

### DIFF
--- a/kn/agenda/entities.py
+++ b/kn/agenda/entities.py
@@ -6,7 +6,8 @@ from django.utils.safestring import mark_safe
 acol = db['agenda']
 
 def ensure_indices():
-    acol.ensure_index('start')
+    acol.ensure_index([('agenda', 1),
+                       ('start', 1)])
 
 def all(agenda=None, limit=None):
     query = {}

--- a/kn/agenda/entities.py
+++ b/kn/agenda/entities.py
@@ -8,23 +8,28 @@ acol = db['agenda']
 def ensure_indices():
     acol.ensure_index('start')
 
-def all(limit=None):
-    cursor = acol.find().sort('start')
+def all(agenda=None, limit=None):
+    query = {}
+    if agenda is not None:
+        query['agenda'] = agenda
+    cursor = acol.find(query).sort('start')
     if limit is not None:
         cursor = cursor.limit(limit)
     for m in cursor:
         yield AgendaEvent(m)
 
-def update(events):
-    """ Clear all current agenda events and replace by events, which is
-        a list of quadrupels (title, description, start, end).
-        See fetch.fetch. """
+def update(agendas):
+    """ Clear all current agenda events and replace by `agendas', which is a
+        dictionary with agendas, where each agenda contains a list of events:
+        quadrupels (title, description, start, end). See fetch.fetch. """
     acol.remove()
-    for title, description, start, end in events:
-        AgendaEvent({'title': title,
-                     'description': description,
-                     'start': start,
-                     'end': end}).save()
+    for key, events in agendas.items():
+        for title, description, start, end in events:
+            AgendaEvent({'agenda': key,
+                         'title': title,
+                         'description': description,
+                         'start': start,
+                         'end': end}).save()
 
 class AgendaEvent(SONWrapper):
     def __init__(self, data):

--- a/kn/agenda/fetch.py
+++ b/kn/agenda/fetch.py
@@ -47,13 +47,10 @@ def parse_item_date(date):
     return parse_date(date['date']+'T00:00:00Z')
 
 
-def fetch():
-    h = httplib2.Http()
-    credentials = get_credentials()
-    credentials.authorize(h)
+def fetch_agenda(h, cal_id):
     timeMin = datetime.datetime.utcnow().date().isoformat() + 'T00:00:00Z'
     cal = build('calendar', 'v3', http=h)
-    request = cal.events().list(calendarId=settings.GOOGLE_CALENDAR_ID,
+    request = cal.events().list(calendarId=cal_id,
                                 timeMin=timeMin,
                                 fields='items(summary,description,start,end)')
     response = request.execute()
@@ -63,6 +60,16 @@ def fetch():
                        parse_item_date(item['start']),
                        parse_item_date(item['end'])))
     return agenda
+
+def fetch():
+    h = httplib2.Http()
+    credentials = get_credentials()
+    credentials.authorize(h)
+
+    agendas = {}
+    for key, cal_id in settings.GOOGLE_CALENDAR_IDS.items():
+        agendas[key] = fetch_agenda(h, cal_id)
+    return agendas
 
 
 if __name__ == '__main__':

--- a/kn/agenda/fetch.py
+++ b/kn/agenda/fetch.py
@@ -56,7 +56,7 @@ def fetch_agenda(h, cal_id):
     response = request.execute()
     agenda = []
     for item in response['items']:
-        agenda.append((item['summary'], item['description'],
+        agenda.append((item['summary'], item.get('description', ''),
                        parse_item_date(item['start']),
                        parse_item_date(item['end'])))
     return agenda

--- a/kn/agenda/templates/agenda/agenda.html
+++ b/kn/agenda/templates/agenda/agenda.html
@@ -2,7 +2,7 @@
 
 {% block body %}
 <div>
-  <a href="http://www.google.com/calendar/embed?src=vssp95jliss0lpr768ec9spbd8%40group.calendar.google.com&amp;ctz=Europe/Paris" target="_blank"
+  <a href="https://www.google.com/calendar/embed?src=vssp95jliss0lpr768ec9spbd8%40group.calendar.google.com&amp;ctz=Europe/Amsterdam" target="_blank"
     >Ook op Google Calendar</a>.
   Ben je geen lid, maar wil je wel op de hoogte blijven van onze activiteiten?
   Zet jezelf op de geïnteresseerden-e-maillijst

--- a/kn/agenda/templates/agenda/agenda.html
+++ b/kn/agenda/templates/agenda/agenda.html
@@ -1,10 +1,4 @@
-{% extends "static/base.html" %}
-
-{% block styles %}
-{{ block.super }}
-<link rel="stylesheet"
-  href="{{ MEDIA_URL }}/agenda/agenda.css" />
-{% endblock styles %}
+{% extends "agenda/base.html" %}
 
 {% block body %}
 <div>
@@ -18,7 +12,7 @@
       <input name="email" type="text" placeholder="jouw@email.com" />
       <input type="submit" value="voeg toe" />
   </form>
-  <p>We hebben ook een <a href="https://www.google.com/calendar/embed?src=a9jl7tuhqg7oe8stapcu9uhvk8%40group.calendar.google.com&ctz=Europe/Amsterdam">gezamelijke agenda</a> met onze <a href="{% url zusjes %}">zusjes</a>!</p>
+  <p>We hebben ook een <a href="{% url agenda-zeus %}">gezamelijke agenda</a> met onze <a href="{% url zusjes %}">zusjes</a>!</p>
 </div>
 
 {% include "agenda/widget.html" %}

--- a/kn/agenda/templates/agenda/base.html
+++ b/kn/agenda/templates/agenda/base.html
@@ -1,0 +1,6 @@
+{% extends "static/base.html" %}
+
+{% block styles %}
+{{ block.super }}
+<link rel="stylesheet" href="{{ MEDIA_URL }}/agenda/agenda.css" />
+{% endblock styles %}

--- a/kn/agenda/templates/agenda/zeus.html
+++ b/kn/agenda/templates/agenda/zeus.html
@@ -3,7 +3,9 @@
 {% block body %}
 
 <div>
-Dit is de ZEUS-agenda, de agenda met alle grote activiteiten van onze <a href="{% url zusjes %}">zusterverenigingen</a> door heel het land.<br/>
+	Dit is de ZEUS-agenda, de agenda met alle grote activiteiten van onze <a href="{% url zusjes %}">zusterverenigingen</a> door heel het land.
+	<a href="https://www.google.com/calendar/embed?src=a9jl7tuhqg7oe8stapcu9uhvk8%40group.calendar.google.com&amp;ctz=Europe/Amsterdam" target="_blank"
+	>Ook op Google Calendar</a>.<br/>
 <a href="{% url agenda %}">Terug naar onze eigen agenda</a>.
 </div>
 

--- a/kn/agenda/templates/agenda/zeus.html
+++ b/kn/agenda/templates/agenda/zeus.html
@@ -1,0 +1,12 @@
+{% extends "agenda/base.html" %}
+
+{% block body %}
+
+<div>
+Dit is de ZEUS-agenda, de agenda met alle grote activiteiten van onze <a href="{% url zusjes %}">zusterverenigingen</a> door heel het land.<br/>
+<a href="{% url agenda %}">Terug naar onze eigen agenda</a>.
+</div>
+
+{% include "agenda/widget.html" %}
+
+{% endblock %}

--- a/kn/agenda/urls.py
+++ b/kn/agenda/urls.py
@@ -6,6 +6,7 @@ import django.views.generic as generic
 
 urlpatterns = patterns('',
     url(r'^agenda/?$', views.agenda, name='agenda'),
+    url(r'^agenda/zeus/?$', views.agenda_zeus, name='agenda-zeus'),
     url(r'^ledenmail-template/?$', views.ledenmail_template,
                     name='ledenmail-template'),
 )

--- a/kn/agenda/views.py
+++ b/kn/agenda/views.py
@@ -4,11 +4,17 @@ import kn.agenda.entities as Es_a
 
 def agenda(request):
     return render_to_response('agenda/agenda.html',
-            {'agenda': Es_a.all()},
+            {'agenda': Es_a.all(agenda='kn')},
             context_instance=RequestContext(request))
+
+def agenda_zeus(request):
+    return render_to_response('agenda/zeus.html',
+            {'agenda': Es_a.all(agenda='zeus')},
+            context_instance=RequestContext(request))
+
 def ledenmail_template(request):
     return render_to_response('agenda/ledenmail-template.html',
-            {'agenda': list(Es_a.all())},
+            {'agenda': list(Es_a.all(agenda='kn'))},
             context_instance=RequestContext(request))
 
 # vim: et:sta:bs=2:sw=4:

--- a/kn/settings.example.py
+++ b/kn/settings.example.py
@@ -97,7 +97,10 @@ EXTERNAL_URLS = {
     'wiki':      'https://karpenoktem.nl/wiki/Hoofdpagina',
     'forum':     'https://karpenoktem.nl/forum/',
 }
-GOOGLE_CALENDAR_ID = 'vssp95jliss0lpr768ec9spbd8@group.calendar.google.com'
+GOOGLE_CALENDAR_IDS = {
+    'kn':   'vssp95jliss0lpr768ec9spbd8@group.calendar.google.com',
+    'zeus': 'a9jl7tuhqg7oe8stapcu9uhvk8@group.calendar.google.com',
+}
 
 # moderation & mailman
 MAILDOMAIN = 'karpenoktem.nl'

--- a/kn/static/templates/static/zusjes.html
+++ b/kn/static/templates/static/zusjes.html
@@ -17,6 +17,8 @@ dat bestaat uit zes verenigingen naast Karpe Noktem; namelijk:
     <li><a href="http://www.wolweze.nl/">Wolw&ecirc;ze</a> uit Leeuwarden.</li>
     </ul>
     <p>Samen met deze verenigingen organiseren wij feesten, weekenden en
-      hebben wij andere samenwerkingsverbanden.</p>
+      hebben wij andere samenwerkingsverbanden.
+      <a href="{% url agenda-zeus %}">Bekijk ook onze gezamelijke agenda!</a>
+    </p>
 {% endblock %}
 {# vim: set sw=2 ts=2 et: #}


### PR DESCRIPTION
Een aparte pagina met de ZEUS agenda. Dit lijkt me de meest eenvoudige manier om die agenda in onze site op te nemen.

Let op: `settings.py` moet hiervoor aangepast worden.