### PR TITLE
Upload nieuwe smoel

### DIFF
--- a/kn/fotos/entities.py
+++ b/kn/fotos/entities.py
@@ -1,5 +1,6 @@
 from kn.leden.mongo import db, SONWrapper, _id, son_property
 import kn.leden.entities as Es
+from kn.fotos.utils import resize_proportional
 from kn import settings
 
 from django.db.models import permalink
@@ -67,17 +68,6 @@ def is_admin(user):
     if user is None:
         return False
     return bool(user.cached_groups_names & frozenset(('fotocie', 'webcie')))
-
-def resize_proportional(width, height, width_max, height_max=None):
-    width = float(width)
-    height = float(height)
-    if width > width_max:
-        height *= width_max/width
-        width  *= width_max/width
-    if height_max is not None and height > height_max:
-        width  *= height_max/height
-        height *= height_max/height
-    return int(round(width)), int(round(height))
 
 def actual_visibility(visibility):
     actual = frozenset(visibility)

--- a/kn/fotos/utils.py
+++ b/kn/fotos/utils.py
@@ -1,0 +1,13 @@
+
+def resize_proportional(width, height, width_max, height_max=None):
+    width = float(width)
+    height = float(height)
+    if width > width_max:
+        height *= width_max/width
+        width  *= width_max/width
+    if height_max is not None and height > height_max:
+        width  *= height_max/height
+        height *= height_max/height
+    return int(round(width)), int(round(height))
+
+# vim: et:sta:bs=2:sw=4:

--- a/kn/leden/entities.py
+++ b/kn/leden/entities.py
@@ -898,6 +898,10 @@ class User(Entity):
     def is_authenticated(self):
         # required by django's auth
         return True
+    def may_upload_smoel_for(self, user):
+        return self == user or \
+                'secretariaat' in self.cached_groups_names or \
+                'bestuur' in self.cached_groups_names
     def push_message(self, msg):
         mcol.insert({'entity': self._id,
                  'data': msg})

--- a/kn/leden/templates/leden/informacie-digest.mail.txt
+++ b/kn/leden/templates/leden/informacie-digest.mail.txt
@@ -56,6 +56,17 @@ Wijzigingen aan de ledenadministratie
 		<a href="{{ BASE_URL }}{{ nt.rel.with.get_absolute_url }}">
 			{{ nt.rel.with.humanName }}</a>.
 	</li>
+{% elif nt.event == 'set_smoel' %}
+	<li><a href="{{ BASE_URL }}{{ nt.user.get_absolute_url }}">
+			{{ nt.user.humanName }}</a>
+		heeft een nieuwe smoel ingesteld voor
+		{% if nt.user == nt.entity %}
+			zichzelf.
+		{% else %}
+			<a href="{{ BASE_URL }}{{ nt.entity.get_absolute_url }}">
+				{{ nt.entity.humanName }}</a>.
+		{% endif %}
+	</li>
 {% endif %}
 {% endfor %}
 </ul>

--- a/kn/leden/templates/leden/user_detail.html
+++ b/kn/leden/templates/leden/user_detail.html
@@ -29,7 +29,7 @@
         enctype="multipart/form-data">
 {% csrf_token %}
 <input type="hidden" name="id" value="{{ object.id }}" />
-<input type="file" name="smoel" />
+<input type="file" name="smoel" accept="image/*" />
 <input type="submit" value="upload smoel" />
 </form>
 {% endif %} {# "secretariaat" in user.cached_groups_names #}

--- a/kn/leden/templates/leden/user_detail.html
+++ b/kn/leden/templates/leden/user_detail.html
@@ -23,7 +23,7 @@
 <input type="submit" value="stuur nieuw wachtwoord" />
 </form>
 {% endif %}{# "secretariaat" in user.cached_groups_names #}
-{% if "secretariaat" in user.cached_groups_names %}
+{% if may_upload_smoel %}
 <h4>Nieuwe smoel uploaden</h4>
 <form method="post" action="{% url ik-chsmoel  %}"
         enctype="multipart/form-data">

--- a/kn/leden/templates/leden/user_detail.html
+++ b/kn/leden/templates/leden/user_detail.html
@@ -12,7 +12,7 @@
 {% if hasPhoto %}
 <div class="smoel"><a href="{{ photosUrl }}"><img
                 src="{% url user-smoel object.name %}"
-                width="{{ photoWidth }}" /></a></div>
+                width="{{ photoWidth }}" height="{{ photoHeight }}"/></a></div>
 {% else %}
 <div class="nosmoel"><a href="{{ photosUrl }}">Foto's</a></div>
 {% endif %}

--- a/kn/leden/views.py
+++ b/kn/leden/views.py
@@ -295,6 +295,7 @@ def ik_chsmoel(request):
             Image.ANTIALIAS)
     img.save(default_storage.open(path.join(settings.SMOELEN_PHOTOS_PATH,
             str(user.name)) + ".jpg", 'w'), "JPEG")
+    Es.notify_informacie('set_smoel', request.user, entity=user)
     return redirect_to_referer(request)
 
 @login_required

--- a/kn/leden/views.py
+++ b/kn/leden/views.py
@@ -148,6 +148,7 @@ def _entity_detail(request, e):
                 'groups': groups,
                 'may_add_related': True,
                 'may_add_rrelated': True})
+    ctx['may_upload_smoel'] = request.user.may_upload_smoel_for(e)
     if e.is_tag:
         ctx.update({'tag_bearers': sorted(e.as_tag().get_bearers(),
                         cmp=Es.entity_cmp_humanName)})
@@ -280,13 +281,13 @@ def users_underage(request):
 
 @login_required
 def ik_chsmoel(request):
-    if not 'secretariaat' in request.user.cached_groups_names:
-        raise PermissionDenied
-    if not 'id' in request.POST:
-        raise ValueError, "Missing `id' in POST"
     if not 'smoel' in request.FILES:
         raise ValueError, "Missing `smoel' in FILES"
+    if not 'id' in request.POST:
+        raise ValueError, "Missing `id' in POST"
     user = Es.by_id(request.POST['id'])
+    if not request.user.may_upload_smoel_for(request.user):
+        raise PermissionDenied
     img = Image.open(request.FILES['smoel'])
     smoelen_width = settings.SMOELEN_WIDTH * 2
     img = img.resize((smoelen_width,

--- a/kn/settings.example.py
+++ b/kn/settings.example.py
@@ -89,6 +89,7 @@ BASE_URL = 'https://karpenoktem.nl'
 ABSOLUTE_MEDIA_URL = BASE_URL + MEDIA_URL
 SMOELEN_PHOTOS_PATH = 'smoelen'
 SMOELEN_WIDTH = 300
+SMOELEN_HEIGHT = 300
 EXTERNAL_URLS = {
     'stukken':   'https://karpenoktem.nl/groups/leden/',
     'wiki':      'https://karpenoktem.nl/wiki/Hoofdpagina',


### PR DESCRIPTION
Leden mogen een nieuwe smoel uploaden voor zichzelf, en bestuur mag dat voor iedereen.
Je zou met elke mobiele browser nu de camera app moeten kunnen kiezen voor het maken van een nieuwe foto, om het nog makkelijker te maken.

Wijzigingen worden in de informacie gelogd als:

```
  * Bas Westerbaan heeft een nieuwe smoel ingesteld voor zichzelf. 
  * Bas Westerbaan heeft een nieuwe smoel ingesteld voor  Ayke Bladiebla. 
```

Die extra spatie is een probleem in html2text, ik heb het gerapporteerd als https://github.com/Alir3z4/html2text/issues/58. Het was al een issue met de veranderde informacie mail template, getriggerd door het verkorten van de regels.

Ik vroeg me nog wel af of we het hier wel een 'smoel' moeten noemen, misschien is 'profielfoto' wat netter?