### PR TITLE
Fix visibility for non-WebCie FotoCie members

### DIFF
--- a/kn/fotos/entities.py
+++ b/kn/fotos/entities.py
@@ -124,7 +124,7 @@ class FotoEntity(SONWrapper):
     def required_visibility(self, user):
         if user is None:
             return frozenset(('world',))
-        if 'webcie' in user.cached_groups_names:
+        if is_admin(user):
             return frozenset(('leden', 'world', 'hidden'))
         if 'leden' in user.cached_groups_names:
             return frozenset(('leden', 'world'))


### PR DESCRIPTION
Blijkbaar mochten fotocie leden wel foto's verplaatsen maar die foto's vervolgens niet zien.

Het probleem was geïntroduceerd in 9a897c9f maar ik heb er echt diverse keren overheen gekeken in verschillende commits.