### PR TITLE
Firefox needs an additional .preventDefault()

### DIFF
--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -718,6 +718,7 @@
   };
 
   KNF.prototype.onedit = function(e) {
+    e.preventDefault();
     e.target.disabled = true;
 
     var field_visibility = $('#album-visibility')


### PR DESCRIPTION
Ik kon albums niet aanpassen in Firefox op Android... dit was denk ik de reden (want dat werkt ook niet goed op de desktopversie).