### PR TITLE
Smoelen home

### DIFF
--- a/kn/leden/templates/leden/base.html
+++ b/kn/leden/templates/leden/base.html
@@ -63,7 +63,7 @@
             {% endif %}
         </li>
 
-        <li><a href="{% external_url "wiki" %}">Wiki</a></li>
+        <li><a href="{% external_url "wiki-home" %}">Wiki</a></li>
         <li><a href="{% external_url "forum" %}">Forum</a></li>
         <li><a href="{% external_url "stukken" %}">Stukken</a></li>
     </ul>

--- a/kn/leden/templates/leden/home.html
+++ b/kn/leden/templates/leden/home.html
@@ -1,22 +1,50 @@
 {% extends "leden/base.html" %}
+{% load base %}
 
 {% block body %}
 <h1>Smoelenboek</h1>
-<p>Hallo <a href="{{ user.get_absolute_url }}">{{user.full_name }}</a>,</p>
-<p>je kunt hier onder andere</p>
+<p>Hallo <a href="{{ user.get_absolute_url }}">{{user.first_name }}</a>,</p>
+
+<p>Karpe Noktem heeft diverse digitale diensten, op deze website en daar
+	buiten:</p>
+
 <ul>
-	<li><a href="{% url entity-by-name name="leden"  %}"
-		>alle leden en oud-leden</a>,</li>
-	<li><a href="{% url tag-by-name name="comms" %}"
-		>alle commissies</a>,</li>
-	<li><a href="{% url entity-by-name name="groepen" %}"
-		>alle groepen</a> en</li>
-	<li>de <a href="{% url entity-by-name name="lists" %}"
-		>e-maillijsten</a></li>
+	<li>De ledenadministratie aka het <a href="{% url smoelen-home %}">
+			smoelenboek</a> (dit hier!). Hier houden we van alles bij, zoals:
+		<ul>
+			<li><a href="{% url entity-by-name name="leden"  %}"
+				>alle leden en oud-leden</a>,</li>
+			<li><a href="{% url tag-by-name name="comms" %}"
+				>alle commissies</a>,</li>
+			<li><a href="{% url entity-by-name name="groepen" %}"
+				>alle groepen</a> en</li>
+			<li>de <a href="{% url entity-by-name name="lists" %}"
+				>e-maillijsten</a>.</li>
+		</ul>
+	</li>
+	<li>Wifi op de villa, zie <a href="{% external_url "wiki" %}/Wifi">
+			het wiki-artikel</a>.</li>
+	<li>Het <a href="{% url fotos "" %}">fotoboek</a>. Je kunt hier ook
+		<a href="{% external_url "wiki" %}/Handleiding:FotosUploaden">
+			foto's naar uploaden</a>!</li>
+	<li>Een <a href="{% external_url "wiki-home" %}">wiki</a> waar iedereen
+		voor de vereniging nuttige informatie op kan plempen.</a>
+	<li>Het <a href="{% external_url "forum" %}">forum</a>, dat helaas
+		nauwelijks meer wordt gebruikt.</li>
+	<li>Een <a href="https://www.facebook.com/groups/170930412922856/">
+			Karpe Noktem groep op Facebook</a>.</li>
+	<li>Het <a href="https://www.facebook.com/groups/279385195413570/">
+			zusjesgroepje op Facebook</a>.</li>
 </ul>
-<p>vinden en jouw 
-<a href="{% url chpasswd %}">Karpe Noktem-wachtwoord veranderen</a>;</p>
-<p>of een <a href="{% url chpasswd-villanet %}">wachtwoord voor het
-villa-netwerk instellen.</a></p>
+
+<h2>Instellingen</h2>
+
+<ul>
+	<li><a href="{{ user.get_absolute_url }}">Verander je profiel
+			(profielfoto, zichbaarheid telefoonnummer)</a></li>
+	<li><a href="{% url chpasswd %}">Verander je wachtwoord</a></li>
+	<li><a href="{% url chpasswd-villanet %}">Stel een wachtwoord in voor wifi
+			op de villa</a></li>
+</ul>
 
 {% endblock %}

--- a/kn/settings.example.py
+++ b/kn/settings.example.py
@@ -94,7 +94,8 @@ SMOELEN_WIDTH = 300
 SMOELEN_HEIGHT = 300
 EXTERNAL_URLS = {
     'stukken':   'https://karpenoktem.nl/groups/leden/',
-    'wiki':      'https://karpenoktem.nl/wiki/Hoofdpagina',
+    'wiki':      'https://karpenoktem.nl/wiki',
+    'wiki-home': 'https://karpenoktem.nl/wiki/Hoofdpagina',
     'forum':     'https://karpenoktem.nl/forum/',
 }
 GOOGLE_CALENDAR_IDS = {

--- a/kn/static/templates/static/links.html
+++ b/kn/static/templates/static/links.html
@@ -20,7 +20,7 @@
 
 <p>Maar vergeet niet</p>
 <ul>
-  <li><a href="{% external_url "wiki" %}">onze wiki</a>,</li>
+  <li><a href="{% external_url "wiki-home" %}">onze wiki</a>,</li>
   <li><a href="{% external_url "forum" %}">ons forum</a> en</li>
   <li>de <a href="{% url zusjes %}">zusjes</a>.</li>
 </ul>


### PR DESCRIPTION
Ik heb eens zitten sleutelen aan de homepage van het smoelenboek, om het wat informatiever te maken en om alles wat Karpe Noktem bied aan digitale diensten op een rijtje te zetten. (Ik zou dit expres hier neer zetten, want dit zien leden, een wiki-artikel zien leden niet).
Ik wil misschien ook nog een uitleg over de mailinglists toevoegen, maar die past naar mijn mening beter op de wiki. Ook wil ik iets toevoegen over ownCloud, maar helaas is er een vereiste dat je je wachtwoord eerst moet veranderen.
![screenshot-asv karpe noktem - google chrome](https://cloud.githubusercontent.com/assets/729697/7234844/65cb97d4-e78a-11e4-920e-5854a96aa346.png)
Heb ik iets gemist?
Zou de agenda en de activiteiten er ook bij moeten? Of SSH/SFTP? Ik hoor graag feedback :)
@dsprenkels @thundur wat vinden jullie ervan?