### PR TITLE
Fotos cache rotatie

### DIFF
--- a/kn/fotos/api.py
+++ b/kn/fotos/api.py
@@ -45,11 +45,11 @@ def entities_json(children, user):
         entry = {'type': child._type,
                  'path': child.full_path,
                  'name': child.name,
-                 'title': child.title}
+                 'title': child.title,
+                 'rotation': child.rotation}
 
         if fEs.is_admin(user):
             entry['visibility'] = child.visibility[0]
-            entry['rotation'] = child.rotation
 
         if child.description:
             entry['description'] = child.description;

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -19,13 +19,11 @@
       this.tags = [];
     }
 
-    this.reload_cache_urls();
+    this.calculate_cache_urls();
   };
 
-  Foto.prototype.reload_cache_urls = function(query) {
-    if (query === undefined) {
-      query = '';
-    }
+  Foto.prototype.calculate_cache_urls = function() {
+    var query = '?rot=' + this.rotation;
     if (this.type == 'album') {
       if (this.thumbnailPath !== undefined) {
         this.thumbnail = this.cache_url('thumb', this.thumbnailPath) + query;
@@ -629,7 +627,7 @@
         delete foto.newRotation;
         if (changed_rotation) {
           // invalidate cached cache urls
-          foto.reload_cache_urls('?rotation='+foto.rotation);
+          foto.calculate_cache_urls();
           this.update_foto_src(foto);
         }
 

--- a/kn/fotos/views.py
+++ b/kn/fotos/views.py
@@ -110,10 +110,15 @@ def cache(request, cache, path):
     lm = strftime("%a, %d %b %Y %H:%M:%S GMT", gmtime(st.st_mtime))
     if request.META.get('HTTP_IF_MODIFIED_SINCE', None) == lm:
         return HttpResponseNotModified()
+    cc = 'max-age=30780000' # Cache-Control header
+    if not entity.may_view(None):
+        # not publicly cacheable
+        cc = 'private, ' + cc
     resp = HttpResponse(FileWrapper(open(entity.get_cache_path(cache))),
                             mimetype=entity.get_cache_mimetype(cache))
     resp['Content-Length'] = str(st.st_size)
     resp['Last-Modified'] = lm
+    resp['Cache-Control'] = cc
     return resp
 
 def compat_view(request):


### PR DESCRIPTION
1. Zet achter elke foto URL `?rot=<rotatie>` zodat rotatie niet zorgt voor uitgerekte foto's (issue #272).
2. Maak foto's praktisch oneindig cachebaar (1 jaar). Browsers limiteren dit automatisch. Zorg tegelijkertijd dat foto's die niet publiekelijk zichtbaar zijn niet door tussenliggende HTTP proxy's gecachet mogen worden (publieke foto's mogen dat wel).