### PR TITLE
Verwijder "... maar je moet nog X bedrag betalen"

### DIFF
--- a/kn/subscriptions/templates/subscriptions/event_detail.html
+++ b/kn/subscriptions/templates/subscriptions/event_detail.html
@@ -67,12 +67,7 @@ copy_emailaddresses_to_clipboard = function() {
 {% block body %}
 {% if subscription %}
 {% if subscription.confirmed %}
-{% if subscription.debit > 0 %}
-<div class="message">Je bent aangemeld, maar moet nog wel
-                {{ subscription.debit }} euro betalen.</div>
-{% else %}{# subscription.debit > 0 #}
 <div class="message">Je bent aangemeld.</div>
-{% endif %}{# subscription.debit > 0 #}
 {% endif %}{# subscription.confirmed #}
 {% endif %}{# subscription #}
 <h1>{{ object.humanName }}</h1>


### PR DESCRIPTION
Hiermee blijft de functionaliteit behouden, mochten we er iets mee willen, maar krijgen de meeste leden geen verwarrende berichten over dat ze nog moeten betalen voor een activiteit waar ze al voor betaald hebben.
Closes #275 