### PR TITLE
Use the same toggle system everywhere (login, submenu, fotoalbum)

### DIFF
--- a/kn/base/media/base.css
+++ b/kn/base/media/base.css
@@ -26,6 +26,19 @@ body {
 	}
 }
 
+
+/* generic classes */
+
+.toggle-window {
+	left: -9999px;
+	position: absolute;
+	top: auto;
+}
+.toggle.toggle-open .toggle-window {
+	left: auto;
+}
+
+
 /* header */
 #header {
 	z-index: 5;
@@ -229,10 +242,12 @@ body {
 }
 
 #submenu {
+	position: static;
 	display: inline-block;
 	margin: 0;
 	line-height: 1;
 	padding: 0;
+	left: auto;
 }
 
 #submenu li {
@@ -325,7 +340,7 @@ body {
 		border-radius: 2px;
 		background: white url('menu.svg') no-repeat 8px 4px;
 	}
-	#submenu-wrapper.open a#submenu-button {
+	#submenu-wrapper.toggle-open a#submenu-button {
 		border-bottom-color: white;
 		border-radius: 2px 2px 0 0;
 	}
@@ -340,7 +355,7 @@ body {
 		padding: 16px 12px;
 		border: 1px solid rgba(127, 127, 127, 0.5);
 	}
-	#submenu-wrapper.open #submenu {
+	#submenu-wrapper.toggle-open #submenu {
 		left: auto;
 		right: 0;
 	}
@@ -413,16 +428,14 @@ textarea {
 
 #loginButtonLink:hover img {
 	-webkit-filter: brightness(115%);
+	filter: brightness(115%);
 }
-#loginButton.open #loginButtonLink img {
+#loginButton.toggle-open #loginButtonLink img {
 	-webkit-filter: brightness(150%);
+	filter: brightness(150%);
 }
 
 #loginWindow {
-	display: none;
-
-	position: absolute;
-	top: auto;
 	right: -12px;
 	margin-top: 8px;
 	max-width: 290px;
@@ -435,10 +448,6 @@ textarea {
 	color: #afafaf;
 	text-transform: none;
 	font-variant: normal;
-}
-
-#loginButton.open #loginWindow {
-	display: block;
 }
 
 @media screen and (max-width: 800px) {

--- a/kn/base/media/common.js
+++ b/kn/base/media/common.js
@@ -128,24 +128,21 @@ $(document).ready(function() {
 
     sessionStorage['visited'] = 'true';
 
-    $('#loginButtonLink').bind('click', function (event) {
-        var loginButton = $('#loginButton');
-        loginButton.toggleClass('open');
-        event.preventDefault();
-        event.stopPropagation();
+    $('.toggle').each(function(i, toggle) {
+        toggle = $(toggle);
+        var btn = $('.toggle-button', toggle);
+        btn.bind('click', function (e) {
+            toggle.toggleClass('toggle-open');
+            e.preventDefault();
+            e.stopPropagation();
+        });
     });
 
-    $(document.body).bind('click', function (event) {
-        $('#loginButton').removeClass('open');
-    });
-
-    $('#loginWindow').bind('click', function (event) {
-        event.stopPropagation();
-    });
-
-    $('#submenu-button').bind('click', function(event) {
-        event.preventDefault();
-        $('#submenu-wrapper').toggleClass('open');
+    $(document.body).bind('click', function (e) {
+        var target = $(e.target);
+        if (target.hasClass('toggle-window') ||
+            target.parents('.toggle-window').length) return;
+        $('.toggle').removeClass('toggle-open');
     });
 });
 

--- a/kn/base/templates/base/base.html
+++ b/kn/base/templates/base/base.html
@@ -37,12 +37,12 @@
                     <li id="loginButton"><a href="{% url smoelen-home %}">{{ user.name }}</a></li>
                     {% else %}{# user.is_authenticated #}
                     <li><a href="{% url lidworden %}">lid worden</a></li>
-                    <li id="loginButton">
-                        <a id="loginButtonLink" href="{% url login %}">
+                    <li id="loginButton" class="toggle">
+                        <a id="loginButtonLink" href="{% url login %}" class="toggle-button">
                             <img src="{{ MEDIA_URL }}/base/login.svg" width="13" height="15" alt=""/>
                             <span class="label">leden</span>
                         </a>
-                        <div id="loginWindow">
+                        <div id="loginWindow" class="toggle-window">
                             <h2>Inloggen voor leden</h2>
                             <p>
                                 Leden kunnen hier inloggen om o.a. het smoelenboek, de wiki en

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -27,27 +27,24 @@ img#album-edit-toggle {
     bottom: -1px;
 }
 #album-edit-toggle:hover,
-#topbar.editor #album-edit-toggle {
+#topbar.toggle-open #album-edit-toggle {
     opacity: 1;
 }
-#topbar.editor #album-edit-toggle {
+#topbar.toggle-open #album-edit-toggle {
     background: white;
     border-color: #aaa;
     border-bottom: 1px white solid;
 }
 
 #album-editor {
-    display: none;
-    position: absolute;
     z-index: 1;
     background: white;
     white-space: nowrap;
-    right: -5px;
     padding: 2px 5px;
     border: 1px #aaa solid;
 }
-#topbar.editor #album-editor {
-    display: block;
+#topbar.toggle-open #album-editor {
+    right: -5px;
 }
 
 p.error {

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -830,10 +830,4 @@
   });
 })();
 
-$(document).ready(function() {
-  $('#album-edit-toggle').click(function() {
-    $('#topbar').toggleClass('editor');
-  });
-});
-
 /* vim: set et sta bs=2 sw=2 : */

--- a/kn/fotos/templates/fotos/fotos.html
+++ b/kn/fotos/templates/fotos/fotos.html
@@ -49,12 +49,13 @@ if ('srcset' in (new Image())) {
 
 {% block body %}
 <div id="breadcrumbs"></div>
-<div id="topbar">
+<div id="topbar" class="toggle">
   <input id="search" type="search" placeholder="zoek..."/>
 {% if fotos_admin %}
-  <img id="album-edit-toggle" src="{{ MEDIA_URL }}/fotos/edit-icon.svg"
-    width="16" height="16" title="Bewerk naam en zichtbaarheid"/>
-  <form id="album-editor">
+  <img id="album-edit-toggle" class="toggle-button"
+    src="{{ MEDIA_URL }}/fotos/edit-icon.svg" width="16" height="16"
+    title="Bewerk naam en zichtbaarheid"/>
+  <form id="album-editor" class="toggle-window">
     <select id="album-visibility"
       onchange="$('#album-edit-button').prop('disabled', false)">
       <option value="world">Publiek</option>

--- a/kn/leden/templates/leden/base.html
+++ b/kn/leden/templates/leden/base.html
@@ -15,9 +15,9 @@
 {% endblock head %}
 
 {% block submenu %}
-<div id="submenu-wrapper">
-    <a id="submenu-button" href="">&nbsp;</a>
-    <ul id="submenu" class="has-dropdown">
+<div id="submenu-wrapper" class="toggle">
+    <a id="submenu-button" class="toggle-button" href="">&nbsp;</a>
+    <ul id="submenu" class="has-dropdown toggle-window">
         <li><a href="{% url smoelen-home %}">Smoelenboek</a>
           <ul>
               <li><a href="{% url entity-by-name name="leden" %}"

--- a/kn/static/templates/static/overbase.html
+++ b/kn/static/templates/static/overbase.html
@@ -1,9 +1,9 @@
 {% extends "static/base.html" %}
 
 {% block submenu %}
-<div id="submenu-wrapper">
-    <a id="submenu-button" href="">&nbsp;</a>
-    <ul id="submenu">
+<div id="submenu-wrapper" class="toggle">
+    <a id="submenu-button" href="" class="toggle-button">&nbsp;</a>
+    <ul id="submenu" class="toggle-window">
         <li><a href="{% url over %}">Over Karpe Noktem</a></li>
         <li><a href="{% url geschiedenis %}">Geschiedenis</a></li>
         <li><a href="{% url activiteiten %}">Activiteiten</a></li>


### PR DESCRIPTION
Hiermee kun je buiten, bijvoorbeeld, het submenu op mobieltjes klikken waarmee dat submenu verdwijnt. Dit werkte al voor de login, maar niet voor het submenu en de fotoalbum-editor.
Getest in Firefox, Chrome en IE9 (als 'low anchor').

IE8 kon ik maar heel beperkt testen, omdat ik niet kon inloggen. Het ziet er naar uit dat de sessiecookie alleen geldig is voor dat path, niet daarbuiten. Ik denk niet dat we die bug willen fixen... (ik heb ook nog niemand horen klagen dat de site niet goed werkte in IE8).