### PR TITLE
Gebruik entities direct ipv via een Worker object

### DIFF
--- a/kn/planning/forms.py
+++ b/kn/planning/forms.py
@@ -3,12 +3,12 @@ import datetime
 from django import forms
 
 import kn.leden.entities as Es
-from kn.planning.entities import Pool, Worker
+from kn.planning.entities import Pool
 
 class WorkerChoiceField(forms.ChoiceField):
     def __init__(self, *args, **kwargs):
         # TODO Reduce these queries into one.
-        kwargs['choices'] = [(e._id, unicode(e.get_user().humanName))
+        kwargs['choices'] = [(e._id, unicode(e.humanName))
                     for e in kwargs['choices']]
         if kwargs.get('sort_choices', False):
             kwargs['choices'].sort(key=lambda x: x[1])
@@ -26,7 +26,7 @@ class ManagePlanningForm(forms.Form):
         for vacancy in vacancies:
             field = WorkerChoiceField(label='%s - %s' % (
                     vacancy.begin_time, vacancy.end_time),
-                    choices=Worker.all_in_pool(pool),
+                    choices=pool.workers(),
                     sort_choices=True,
                     initial=vacancy.assignee_id,
                     required=False)

--- a/kn/planning/score.py
+++ b/kn/planning/score.py
@@ -175,7 +175,7 @@ preferences = {
 }}
 
 def planning_vacancy_worker_score(vacancy, worker):
-    un = worker.username
+    un = str(worker.name)
     pn = vacancy.pool.name
     if pn not in preferences or un not in preferences[pn]:
         # If the preferences of a worker have not been set,

--- a/kn/planning/templates/planning/manage.html
+++ b/kn/planning/templates/planning/manage.html
@@ -1,5 +1,6 @@
 {% extends "leden/base.html" %}
 {% load base %}
+{% load planning %}
 
 {% block body %}
 <script type="text/javascript">
@@ -60,8 +61,8 @@
         id="more_element_{{ vacancy.formField.name }}">more...</a><span
         style="display: none" id="more_{{ vacancy.formField.name }}">{% endif %}
         <a href="javascript:set_select_by_id('id_{{ vacancy.formField.name }}', '{{ suggestion.scorer.id }}');" 
-                title="{{ suggestion.score }} - {{ suggestion.scorer.last_shift }}"
-                >{{ suggestion.scorer.get_user.name }}</a>{% if not forloop.last %},{% endif %}
+                title="{{ suggestion.score }} - {{ suggestion.scorer|last_shift:pool }}"
+                >{{ suggestion.scorer.name }}</a>{% if not forloop.last %},{% endif %}
 {% if forloop.last and forloop.counter > 5 %}</span>{% endif %}
 {% endfor %}
             </td>
@@ -69,7 +70,7 @@
 {% empty %}
         <tr>
             <td colspan="2">
-                    Er zijn geen diensten voor de pool {{ pool }}.
+                    Er zijn geen diensten voor de pool {{ pool.name }}.
             </td>
         </tr>
 {% endfor %}

--- a/kn/planning/templates/planning/template.html
+++ b/kn/planning/templates/planning/template.html
@@ -12,7 +12,7 @@
 {% for assignee in vacancy.assignees %}
 {% if not forloop.first %}+{% endif %}
 {% if assignee %}
-            {{ assignee.user.humanName }}
+            {{ assignee.humanName }}
 {% else %}
             <span style="color: red">Iemand</span>
 {% endif %}

--- a/kn/planning/templatetags/planning.py
+++ b/kn/planning/templatetags/planning.py
@@ -1,0 +1,9 @@
+from django import template
+
+register = template.Library()
+
+@register.filter(name='last_shift')
+def last_shift_filter(worker, pool):
+    return pool.last_shift(worker)
+
+# vim: et:sta:bs=2:sw=4:

--- a/kn/planning/utils.py
+++ b/kn/planning/utils.py
@@ -17,8 +17,8 @@ def send_reminder(vacancy, update=True):
     ccs = map(lambda x: Es.by_name(x).canonical_full_email, p.reminder_cc)
     subj = '%s, %s' % (vacancy.name.capitalize(), edate)
     em = EmailMessage(subj, msg, to=[to.canonical_full_email], headers={
-            'Reply-To': Es.by_name(p.administrator).canonical_full_email,
-            'CC': ', '.join(ccs)}, bcc=ccs)
+            'Reply-To': Es.by_name(p.administrator).canonical_full_email},
+        cc=ccs, bcc=ccs)
     em.send()
     if update:
         vacancy.reminder_needed = False

--- a/kn/planning/utils.py
+++ b/kn/planning/utils.py
@@ -3,7 +3,7 @@ from django.core.mail import EmailMessage
 import kn.leden.entities as Es
 
 def send_reminder(vacancy, update=True):
-    to = vacancy.assignee.get_user()
+    to = vacancy.assignee
     e = vacancy.event
     p = vacancy.pool
     edate = e.date.strftime('%A %d %B')

--- a/utils/one-shot/2015-04-25-pool-use-entities.py
+++ b/utils/one-shot/2015-04-25-pool-use-entities.py
@@ -1,0 +1,26 @@
+import _import
+
+import kn.leden.entities as Es
+from kn.planning.entities import Vacancy
+from kn.leden.mongo import db, _id
+
+wcol = db['planning_workers']
+
+def main():
+    count = 0
+    for vacancy in Vacancy.all():
+        if vacancy.assignee_id is None:
+            continue
+        worker_data = wcol.find_one({'_id': vacancy.assignee_id})
+        if worker_data is None:
+            continue
+        user = Es.by_id(worker_data['user'])
+        vacancy._data['assignee'] = _id(user)
+        vacancy.save()
+        count += 1
+    print 'Converted %d vacancies.' % count
+
+if __name__ == '__main__':
+    main()
+
+# vim: et:sta:bs=2:sw=4:


### PR DESCRIPTION
Dan is het niet meer nodig mensen apart toe te voegen aan de lijsten en weer te verwijderen van de lijsten. Toevoegen aan bijvoorbeeld 'tappers' is genoeg om iemand in de planning te laten verschijnen. Dit betekent ook dat die lijsten misschien nog een keertje nagekeken moeten worden, als er nu verschillen zijn tussen die lijsten, voordat iemand ineens ingepland wordt die dat niet verwacht bijvoorbeeld.

Ik heb dit zoveel mogelijk lokaal getest, maar misschien heb ik functies in de planning over het hoofd gezien.

Closes #281 