### PR TITLE
Do not install apache2

### DIFF
--- a/salt/states/sankhara/init.sls
+++ b/salt/states/sankhara/init.sls
@@ -1,6 +1,6 @@
 include:
+    - .nginx
     - .mail
     - .mongo
     - .kninfra
-    - .nginx
     - .initializeDb


### PR DESCRIPTION
mailman installeert apache2 als er geen httpd is geïnstalleerd, dus installeer nginx eerst