### PR TITLE
Support the Debian package python-googleapi

### DIFF
--- a/kn/agenda/fetch.py
+++ b/kn/agenda/fetch.py
@@ -8,9 +8,13 @@ import httplib2
 
 from iso8601 import parse_date
 
-# pip install google-api-python-client
+try:
+    # Debian package python-googleapi
+    from apiclient.discovery import build
+except ImportError:
+    # pip package google-api-python-client
+    from googleapiclient.discovery import build
 from oauth2client.client import SignedJwtAssertionCredentials
-from googleapiclient.discovery import build
 
 # How to configure the agenda:
 #


### PR DESCRIPTION
Hiermee kun je het Debian pakket `python-googleapi` gebruiken, met automatische updates, in plaats van het pip pakket `google-api-python-client` (IIRC).