### PR TITLE
Hardcode `kn.settings` niet

### DIFF
--- a/kn/agenda/fetch.py
+++ b/kn/agenda/fetch.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-import kn.settings as settings
+from django.conf import settings
 
 import json
 import datetime

--- a/kn/barco/views.py
+++ b/kn/barco/views.py
@@ -12,7 +12,7 @@ from django.template import RequestContext
 
 from koert.drank.rikf import open_rikf_ar
 
-from kn import settings
+from django.conf import settings
 from kn.barco.forms import BarformMeta, InvCountMeta
 
 settings.DRANK_REPOSITORIES = ['drank6', 'drank7', 'drank8', 'drank9']

--- a/kn/base/conf.py
+++ b/kn/base/conf.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+
+def from_settings_import(*args):
+    """     from_settings_import('SOME_VARIABLE', 'DT_MIN', globals())
+    
+        does what you would expect the following to do
+    
+            from django.conf.settings import SOME_VARIABLE, DT_MIN """
+    for name in args[:-1]:
+        args[-1][name] = getattr(settings, name)
+
+# vim: et:sta:bs=2:sw=4:

--- a/kn/base/context_processors.py
+++ b/kn/base/context_processors.py
@@ -1,7 +1,8 @@
 import random
-from kn.settings import ABSOLUTE_MEDIA_URL
+
+from django.conf import settings
 
 def base_url(request):
-    return {'ABSOLUTE_MEDIA_URL': ABSOLUTE_MEDIA_URL}
+    return {'ABSOLUTE_MEDIA_URL': settings.ABSOLUTE_MEDIA_URL}
 
 # vim: et:sta:bs=2:sw=4:

--- a/kn/base/mail.py
+++ b/kn/base/mail.py
@@ -4,7 +4,7 @@ import django.template
 import django.template.loader
 import django.core.mail
 
-from kn import settings
+from django.conf import settings
 
 def render_then_email(template_name, to, ctx={}, cc=[], bcc=[], from_email=None,
                         reply_to=None, headers=None):

--- a/kn/fotos/entities.py
+++ b/kn/fotos/entities.py
@@ -1,7 +1,7 @@
 from kn.leden.mongo import db, SONWrapper, _id, son_property
 import kn.leden.entities as Es
 from kn.fotos.utils import resize_proportional
-from kn import settings
+from django.conf import settings
 
 from django.db.models import permalink
 

--- a/kn/fotos/forms.py
+++ b/kn/fotos/forms.py
@@ -1,14 +1,10 @@
-import os
-from glob import glob
 from datetime import date
 
 from django import forms
 
-from kn.settings import PHOTOS_DIR, USER_DIRS, WOLK_DATA_PATH
 from kn.leden import giedo
 
 import kn.fotos.entities as fEs
-from kn.fotos.roots import FOTO_ROOTS
 
 
 def list_events():

--- a/kn/fotos/roots.py
+++ b/kn/fotos/roots.py
@@ -1,4 +1,4 @@
-from kn import settings
+from django.conf import settings
 
 from collections import namedtuple
 foto_root = namedtuple('foto_root', ('base', 'between'))

--- a/kn/fotos/views.py
+++ b/kn/fotos/views.py
@@ -19,7 +19,6 @@ from django.contrib import messages
 from django.http import Http404, HttpResponse, HttpResponseNotModified, QueryDict
 
 from kn.fotos.forms import CreateEventForm, getMoveFotosForm, list_events
-from kn.settings import PHOTOS_DIR
 from kn.leden import giedo
 
 import kn.fotos.entities as fEs

--- a/kn/leden/entities.py
+++ b/kn/leden/entities.py
@@ -10,6 +10,7 @@ from django.db.models import permalink
 from kn.leden.date import now
 from kn.leden.mongo import db, SONWrapper, _id, son_property
 from kn.base._random import pseudo_randstr
+
 from kn.settings import DT_MIN, DT_MAX
 
 # ######################################################################

--- a/kn/leden/entities.py
+++ b/kn/leden/entities.py
@@ -4,13 +4,13 @@ import datetime
 import functools
 import email.utils
 
+from django.conf import settings
 from django.db.models import permalink
 
 from kn.leden.date import now
 from kn.leden.mongo import db, SONWrapper, _id, son_property
-from kn.settings import DT_MIN, DT_MAX, MAILDOMAIN
 from kn.base._random import pseudo_randstr
-from kn import settings
+from kn.settings import DT_MIN, DT_MAX
 
 # ######################################################################
 # The collections
@@ -907,7 +907,7 @@ class Entity(SONWrapper):
         if self.type in ('institute', 'study', 'brand', 'tag'):
             return None
         name = str(self.name if self.name else self.id)
-        return "%s@%s" % (name, MAILDOMAIN)
+        return "%s@%s" % (name, settings.MAILDOMAIN)
 
     @property
     def got_mailman_list(self):

--- a/kn/leden/entities.py
+++ b/kn/leden/entities.py
@@ -11,7 +11,8 @@ from kn.leden.date import now
 from kn.leden.mongo import db, SONWrapper, _id, son_property
 from kn.base._random import pseudo_randstr
 
-from kn.settings import DT_MIN, DT_MAX
+from kn.base.conf import from_settings_import
+from_settings_import("DT_MIN", "DT_MAX", globals())
 
 # ######################################################################
 # The collections

--- a/kn/leden/giedo.py
+++ b/kn/leden/giedo.py
@@ -1,6 +1,6 @@
 import time
 
-from kn import settings
+from django.conf import settings
 
 from kn.utils.whim import WhimDaemon, WhimClient
 

--- a/kn/leden/mongo.py
+++ b/kn/leden/mongo.py
@@ -5,10 +5,10 @@ try:
 except ImportError:
     from bson import ObjectId
 
-from kn.settings import MONGO_DB, MONGO_HOST
+from django.conf import settings
 
-conn = pymongo.Connection(MONGO_HOST)
-db = conn[MONGO_DB]
+conn = pymongo.Connection(settings.MONGO_HOST)
+db = conn[settings.MONGO_DB]
 
 def _id(obj):
     if isinstance(obj, ObjectId):

--- a/kn/leden/utils.py
+++ b/kn/leden/utils.py
@@ -1,5 +1,5 @@
 import kn.leden.entities as Es
-from kn import settings
+from django.conf import settings
 
 def find_name_for_user(first_name, last_name):
     """ Given the first and the last name of a user, find a free name """

--- a/kn/leden/views.py
+++ b/kn/leden/views.py
@@ -36,7 +36,8 @@ from kn.base.text import humanized_enum
 
 from kn.fotos.utils import resize_proportional
 
-from kn.settings import DT_MIN, DT_MAX
+from kn.base.conf import from_settings_import
+from_settings_import("DT_MIN", "DT_MAX", globals())
 from django.conf import settings
 
 import kn.leden.entities as Es

--- a/kn/leden/views.py
+++ b/kn/leden/views.py
@@ -37,7 +37,7 @@ from kn.base.text import humanized_enum
 from kn.fotos.utils import resize_proportional
 
 from kn.settings import DT_MIN, DT_MAX
-from kn import settings
+from django.conf import settings
 
 import kn.leden.entities as Es
 

--- a/kn/moderation/views.py
+++ b/kn/moderation/views.py
@@ -12,7 +12,7 @@ import kn.leden.entities as Es
 import kn.moderation.entities as mod_Es
 from kn.utils.mailman import import_mailman
 from kn.base.mail import render_then_email
-from kn import settings
+from django.conf import settings
 
 import_mailman()
 

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -3,10 +3,10 @@ import decimal
 from django.db.models import permalink
 from django.utils.html import escape, linebreaks
 from django.core.mail import EmailMessage
+from django.conf import settings
 
 from kn.leden.mongo import db, SONWrapper, _id, son_property, ObjectId
 import kn.leden.entities as Es
-from kn.settings import MAILDOMAIN
 
 ecol = db['events']
 scol = db['event_subscriptions']
@@ -100,7 +100,8 @@ class Event(SONWrapper):
     @property
     def messageId(self):
         """ Unique ID to be used in e.g. References: headers """
-        return '<%s@%s>' % (self.get_absolute_url().strip('/'), MAILDOMAIN)
+        return '<%s@%s>' % (self.get_absolute_url().strip('/'),
+                        settings.MAILDOMAIN)
     def has_read_access(self, user):
         return  self.owner == user or \
             str(self.owner.name) in user.cached_groups_names or \

--- a/kn/utils/cilia/__init__.py
+++ b/kn/utils/cilia/__init__.py
@@ -6,7 +6,7 @@ import select
 import json
 import os
 
-from kn import settings
+from django.conf import settings
 
 from kn.utils.whim import WhimDaemon
 from kn.utils.cilia.unix import set_unix_map, unix_setpass

--- a/kn/utils/cilia/fotoadmin.py
+++ b/kn/utils/cilia/fotoadmin.py
@@ -2,7 +2,7 @@ import subprocess
 import os.path
 import re
 
-from kn import settings
+from django.conf import settings
 from kn.fotos.roots import FOTO_ROOTS
 
 def fotoadmin_remove_moved_fotos(cilia, store, user, directory):

--- a/kn/utils/cilia/wolk.py
+++ b/kn/utils/cilia/wolk.py
@@ -5,7 +5,7 @@ import os.path
 import logging
 import subprocess
 
-from kn import settings
+from django.conf import settings
 
 def wolk_setpass(cilia, user, passwd):
     wolk_script = os.path.join(os.path.dirname(os.path.realpath(__file__)),

--- a/kn/utils/daan/__init__.py
+++ b/kn/utils/daan/__init__.py
@@ -17,7 +17,7 @@ from kn.utils.daan.live import live_update_knsite, live_update_knfotos
 from kn.utils.daan.fotoadmin import fotoadmin_create_event, fotoadmin_move_fotos
 from kn.utils.daan._ldap import apply_ldap_changes, ldap_setpass
 
-from kn import settings
+from django.conf import settings
 
 class Daan(WhimDaemon):
     def __init__(self):

--- a/kn/utils/daan/_ldap.py
+++ b/kn/utils/daan/_ldap.py
@@ -2,7 +2,7 @@ import ldap
 import ldap.modlist
 import smbpasswd
 
-from kn import settings
+from django.conf import settings
 
 def ldap_setpass(daan, user, password):
     if not password:

--- a/kn/utils/daan/forum.py
+++ b/kn/utils/daan/forum.py
@@ -5,7 +5,7 @@ import time
 
 import MySQLdb
 
-from kn import settings
+from django.conf import settings
 from kn.base._random import pseudo_randstr
 
 def forum_setpass(daan, user, password):

--- a/kn/utils/daan/fotoadmin.py
+++ b/kn/utils/daan/fotoadmin.py
@@ -9,7 +9,7 @@ import re
 
 
 import kn.fotos.entities as fEs
-from kn.fotos.forms import FOTO_ROOTS
+from kn.fotos.roots import FOTO_ROOTS
 from django.conf import settings
 
 def fotoadmin_create_event(daan, date, name, humanName):

--- a/kn/utils/daan/fotoadmin.py
+++ b/kn/utils/daan/fotoadmin.py
@@ -10,7 +10,7 @@ import re
 
 import kn.fotos.entities as fEs
 from kn.fotos.forms import FOTO_ROOTS
-from kn import settings
+from django.conf import settings
 
 def fotoadmin_create_event(daan, date, name, humanName):
     if not re.match('^20\d{2}-\d{2}-\d{2}$', date):

--- a/kn/utils/daan/mailman.py
+++ b/kn/utils/daan/mailman.py
@@ -2,7 +2,7 @@ from subprocess import call
 import logging
 import os
 
-from kn import settings
+from django.conf import settings
 
 from kn.utils.mailman import import_mailman
 import_mailman()

--- a/kn/utils/daan/postfix.py
+++ b/kn/utils/daan/postfix.py
@@ -2,24 +2,24 @@ import logging
 
 import os.path
 
-from kn.settings import POSTFIX_VIRTUAL_MAP, POSTFIX_SLM_MAP
+from django.conf import settings
 from subprocess import call
 
 def set_postfix_slm_map(daan, tbl):
     # TODO check whether the entries are valid and within karpenoktem.nl!
-    with open(POSTFIX_SLM_MAP, 'w') as f:
+    with open(settings.POSTFIX_SLM_MAP, 'w') as f:
         for k, v in tbl.iteritems():
             f.write("%s %s\n" % (k, ', '.join(v)))
-    call(['postmap', POSTFIX_SLM_MAP])
+    call(['postmap', settings.POSTFIX_SLM_MAP])
 
 def set_postfix_map(daan, tbl):
     # TODO check whether the entries are valid and within karpenoktem.nl!
-    with open(POSTFIX_VIRTUAL_MAP, 'w') as f:
+    with open(settings.POSTFIX_VIRTUAL_MAP, 'w') as f:
         for k, v in tbl.iteritems():
             v = filter(lambda x: x, v)
             if not v:
                 continue
             f.write("%s %s\n" % (k, ', '.join(v)))
-    call(['postmap', POSTFIX_VIRTUAL_MAP])
+    call(['postmap', settings.POSTFIX_VIRTUAL_MAP])
 
 # vim: et:sta:bs=2:sw=4:

--- a/kn/utils/daan/wiki.py
+++ b/kn/utils/daan/wiki.py
@@ -4,7 +4,7 @@ import subprocess
 
 import MySQLdb
 
-from kn import settings
+from django.conf import settings
 from kn.base._random import pseudo_randstr
 
 def wiki_setpass(daan, user, password):

--- a/kn/utils/giedo/__init__.py
+++ b/kn/utils/giedo/__init__.py
@@ -16,7 +16,7 @@ from M2Crypto import RSA
 
 from django.core.files.storage import default_storage
 
-from kn import settings
+from django.conf import settings
 from kn.utils.whim import WhimDaemon, WhimClient
 from kn.base._random import pseudo_randstr
 import kn.leden.entities as Es

--- a/kn/utils/giedo/_ldap.py
+++ b/kn/utils/giedo/_ldap.py
@@ -4,7 +4,7 @@ import ldap
 
 import kn.leden.entities as Es
 
-from kn import settings
+from django.conf import settings
 
 def generate_ldap_changes(giedo):
     if not settings.LDAP_PASS:

--- a/kn/utils/giedo/db.py
+++ b/kn/utils/giedo/db.py
@@ -2,7 +2,8 @@ import logging
 
 import kn.leden.entities as Es
 from kn.leden.date import now
-from kn.settings import DT_MIN, DT_MAX
+from kn.base.conf import from_settings_import
+from_settings_import("DT_MIN", "DT_MAX", globals())
 
 def update_db(giedo):
     dt_now = now()

--- a/kn/utils/giedo/forum.py
+++ b/kn/utils/giedo/forum.py
@@ -5,7 +5,7 @@ import MySQLdb
 
 import kn.leden.entities as Es
 
-from kn import settings
+from django.conf import settings
 
 def generate_forum_changes(self):
     creds = settings.FORUM_MYSQL_SECRET

--- a/kn/utils/giedo/fotos.py
+++ b/kn/utils/giedo/fotos.py
@@ -1,4 +1,4 @@
-from kn import settings
+from django.conf import settings
 import kn.fotos.entities as fEs
 import kn.leden.entities as Es
 

--- a/kn/utils/giedo/openvpn.py
+++ b/kn/utils/giedo/openvpn.py
@@ -10,7 +10,7 @@ from django.core.mail import EmailMessage
 from django.core.urlresolvers import reverse
 
 import kn.leden.entities as Es
-from kn import settings
+from django.conf import settings
 
 class CreateCertificateException(Exception):
     pass

--- a/kn/utils/giedo/postfix.py
+++ b/kn/utils/giedo/postfix.py
@@ -2,9 +2,10 @@ import logging
 
 from tarjan.tc import tc
 
+from django.conf import settings
+
 import kn.leden.entities as Es
 from kn.leden.date import now
-from kn.settings import LISTS_MAILDOMAIN, MAILDOMAIN
 
 # TODO (issue #7) handle cycles properly.
 
@@ -19,19 +20,19 @@ def generate_postfix_map(giedo):
             continue
         id2email[e._id] = e.canonical_email
         for nm in e.other_names:
-            tbl["%s@%s" % (nm, MAILDOMAIN)] = (e.canonical_email,)
+            tbl["%s@%s" % (nm, settings.MAILDOMAIN)] = (e.canonical_email,)
         if e.type == 'user':
             tbl[e.canonical_email] = (e.primary_email,)
         elif e.type == 'group':
             if e.got_mailman_list and e.name:
                 tbl[e.canonical_email] = ('%s@%s' % (
-                    str(e.name), LISTS_MAILDOMAIN),)
+                    str(e.name), settings.LISTS_MAILDOMAIN),)
             else:
                 tbl[e.canonical_email] = []
                 non_mailman_groups[e._id] = e
         else:
             logging.warn("postfix: unhandled type: %s" % e.type)
-        id_email = "%s@%s" % (e.id, MAILDOMAIN)
+        id_email = "%s@%s" % (e.id, settings.MAILDOMAIN)
         if not id_email in tbl:
             tbl[id_email] = (e.canonical_email,)
     # handle the non-mailman groups
@@ -100,7 +101,7 @@ def generate_postfix_slm_map(giedo):
     for name, users in tbl.iteritems():
         if not users:
             continue
-        ret["%s@%s" % (name, MAILDOMAIN)] = tuple(users)
+        ret["%s@%s" % (name, settings.MAILDOMAIN)] = tuple(users)
     return ret
 
 # vim: et:sta:bs=2:sw=4:

--- a/kn/utils/giedo/unix.py
+++ b/kn/utils/giedo/unix.py
@@ -4,7 +4,8 @@ import itertools
 from tarjan.tc import tc        # transitive closure of a graph
 
 import kn.leden.entities as Es
-from kn.settings import DT_MIN, DT_MAX
+from kn.base.conf import from_settings_import
+from_settings_import("DT_MIN", "DT_MAX", globals())
 from kn.leden.date import now
 
 def generate_unix_map(giedo):

--- a/kn/utils/giedo/unix.py
+++ b/kn/utils/giedo/unix.py
@@ -4,7 +4,7 @@ import itertools
 from tarjan.tc import tc        # transitive closure of a graph
 
 import kn.leden.entities as Es
-from kn.settings import DT_MIN
+from kn.settings import DT_MIN, DT_MAX
 from kn.leden.date import now
 
 def generate_unix_map(giedo):

--- a/kn/utils/giedo/wiki.py
+++ b/kn/utils/giedo/wiki.py
@@ -4,7 +4,7 @@ import itertools
 import MySQLdb
 
 import kn.leden.entities as Es
-from kn import settings
+from django.conf import settings
 
 def generate_wiki_changes(self):
     creds = settings.WIKI_MYSQL_SECRET

--- a/kn/utils/giedo/wolk.py
+++ b/kn/utils/giedo/wolk.py
@@ -7,7 +7,7 @@ import kn.leden.entities as Es
 from kn.settings import DT_MIN
 from kn.leden.date import now
 
-from kn import settings
+from django.conf import settings
 
 def generate_wolk_changes(giedo):
     creds = settings.WOLK_MYSQL_SECRET

--- a/kn/utils/giedo/wolk.py
+++ b/kn/utils/giedo/wolk.py
@@ -4,7 +4,8 @@ import MySQLdb
 from tarjan.tc import tc
 
 import kn.leden.entities as Es
-from kn.settings import DT_MIN, DT_MAX
+from kn.base.conf import from_settings_import
+from_settings_import("DT_MIN", "DT_MAX", globals())
 from kn.leden.date import now
 
 from django.conf import settings

--- a/kn/utils/giedo/wolk.py
+++ b/kn/utils/giedo/wolk.py
@@ -4,7 +4,7 @@ import MySQLdb
 from tarjan.tc import tc
 
 import kn.leden.entities as Es
-from kn.settings import DT_MIN
+from kn.settings import DT_MIN, DT_MAX
 from kn.leden.date import now
 
 from django.conf import settings

--- a/salt/states/sankhara/infra.profile
+++ b/salt/states/sankhara/infra.profile
@@ -5,3 +5,5 @@ fi
 if [ -d "$HOME/py" ] ; then
     export PYTHONPATH="$HOME/py:$PYTHONPATH"
 fi
+
+export DJANGO_SETTINGS_MODULE=kn.settings

--- a/salt/states/sankhara/kninfra.sls
+++ b/salt/states/sankhara/kninfra.sls
@@ -39,7 +39,11 @@ infra:
             {% endif %}
 /home/infra/.profile:
     file.managed:
-        - source: salt://sankhara/profile
+        - source: salt://sankhara/infra.profile
+/root/.profile:
+    file.managed:
+        - source: salt://sankhara/root.profile
+        - template: jinja
 {% if grains['vagrant'] %}
 /home/infra/repo:
     file.symlink:
@@ -47,6 +51,15 @@ infra:
 /root/kninfra:
     file.symlink:
         - target: /vagrant
+/root/py:
+    file.directory
+/root/py/vagrantSettingsHack:
+    file.directory
+/root/py/vagrantSettingsHack/__init__.py:
+    file.managed
+/root/py/vagrantSettingsHack/settings.py:
+    file.symlink:
+        - target: /root/settings.py
 {% else %}
 "kninfra clone infra":
     git.latest:

--- a/salt/states/sankhara/root.profile
+++ b/salt/states/sankhara/root.profile
@@ -1,0 +1,13 @@
+if [ -d "$HOME/bin" ] ; then
+    export PATH="$HOME/bin:$PATH"
+fi
+
+if [ -d "$HOME/py" ] ; then
+    export PYTHONPATH="$HOME/py:$PYTHONPATH"
+fi
+
+{% if grains['vagrant'] %}
+export DJANGO_SETTINGS_MODULE=vagrantSettingsHack.settings
+{% else %}
+export DJANGO_SETTINGS_MODULE=kn.settings
+{% endif %}

--- a/utils/_import.py
+++ b/utils/_import.py
@@ -23,7 +23,7 @@ def setup_virtual_package(name, path=os.curdir):
 
 
 if __name__ != '__main__':
-    os.environ['DJANGO_SETTINGS_MODULE'] = 'kn.settings'
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "kn.settings")
     path = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(
         os.path.realpath(__file__[:-1] if __file__[-4:] in
             ('.pyc', '.pyo') else __file__))), '../kn'))

--- a/utils/anonymized-dump/create.py
+++ b/utils/anonymized-dump/create.py
@@ -4,7 +4,8 @@ import _import
 # Please make very sure that this script is up-to-date.  It is a crime
 # to leak private data entrusted to us.
 
-from kn.settings import DT_MIN, DT_MAX
+from kn.base.conf import from_settings_import
+from_settings_import("DT_MIN", "DT_MAX", globals())
 from kn.leden.mongo import db
 
 import bson

--- a/utils/leden/check-integrity.py
+++ b/utils/leden/check-integrity.py
@@ -3,7 +3,8 @@ import _import
 
 import kn.leden.entities as Es
 from kn.leden.mongo import _id
-from kn.settings import DT_MIN, DT_MAX
+from kn.base.conf import from_settings_import
+from_settings_import("DT_MIN", "DT_MAX", globals())
 
 # Do some too-intensive-for-Giedo sanity checks on the database
 # Currently, check for orphan relations.

--- a/utils/leden/graphs-iriss.py
+++ b/utils/leden/graphs-iriss.py
@@ -12,7 +12,8 @@ import _import
 import datetime
 
 import kn.leden.entities as Es
-from kn.settings import DT_MIN, DT_MAX
+from kn.base.conf import from_settings_import
+from_settings_import("DT_MIN", "DT_MAX", globals())
 from kn.leden.mongo import _id
 
 llut = dict()

--- a/utils/one-shot/2012-04-27-correct-ledenStartDate.py
+++ b/utils/one-shot/2012-04-27-correct-ledenStartDate.py
@@ -14,7 +14,8 @@ import datetime
 
 import kn.leden.entities as Es
 from kn.leden.mongo import _id
-from kn.settings import DT_MIN, DT_MAX
+from kn.base.conf import from_settings_import
+from_settings_import("DT_MIN", "DT_MAX", globals())
 
 
 def main():

--- a/utils/one-shot/2012-08-25-remove-empty-entries.py
+++ b/utils/one-shot/2012-08-25-remove-empty-entries.py
@@ -7,7 +7,8 @@ import datetime
 
 import kn.leden.entities as Es
 from kn.leden.mongo import _id
-from kn.settings import DT_MIN, DT_MAX
+from kn.base.conf import from_settings_import
+from_settings_import("DT_MIN", "DT_MAX", globals())
 
 def main():
     for e in Es.users():

--- a/utils/one-shot/2012-08-26-year-overrides.py
+++ b/utils/one-shot/2012-08-26-year-overrides.py
@@ -8,7 +8,8 @@ import datetime
 
 import kn.leden.entities as Es
 from kn.leden.mongo import _id
-from kn.settings import DT_MIN, DT_MAX
+from kn.base.conf import from_settings_import
+from_settings_import("DT_MIN", "DT_MAX", globals())
 
 def main():
     # Fetch year overrides

--- a/utils/one-shot/2014-09-27-import-fotos.py
+++ b/utils/one-shot/2014-09-27-import-fotos.py
@@ -1,6 +1,6 @@
 import _import
 
-from kn import settings
+from django.conf import settings
 import kn.fotos.entities as fEs
 import kn.leden.entities as Es
 

--- a/utils/one-shot/2014-10-27-mailman-updates.py
+++ b/utils/one-shot/2014-10-27-mailman-updates.py
@@ -1,7 +1,7 @@
 # vim: et:sta:bs=2:sw=4:
 import _import
 
-from kn import settings
+from django.conf import settings
 from kn.utils.mailman import import_mailman
 
 import_mailman()

--- a/utils/one-shot/2015-03-25-cache-foto.py
+++ b/utils/one-shot/2015-03-25-cache-foto.py
@@ -1,6 +1,6 @@
 import _import
 
-from kn import settings
+from django.conf import settings
 import kn.fotos.entities as fEs
 import kn.leden.entities as Es
 import multiprocessing

--- a/utils/planning/add-borrel.py
+++ b/utils/planning/add-borrel.py
@@ -5,7 +5,8 @@ import sys
 import datetime
 
 import kn.leden.entities as Es
-from kn.settings import DT_MIN, DT_MAX
+from kn.base.conf import from_settings_import
+from_settings_import("DT_MIN", "DT_MAX", globals())
 from kn.leden.mongo import _id
 from kn.planning.entities import Pool, Worker, Event, Vacancy
 

--- a/utils/planning/add-dranktelling.py
+++ b/utils/planning/add-dranktelling.py
@@ -6,7 +6,8 @@ import datetime
 
 import kn.leden.entities as Es
 from kn.leden.mongo import _id
-from kn.settings import DT_MIN, DT_MAX
+from kn.base.conf import from_settings_import
+from_settings_import("DT_MIN", "DT_MAX", globals())
 from kn.planning.entities import Pool, Worker, Event, Vacancy
 
 def hm2s(hours, minutes=0):

--- a/utils/restore-from-old.py
+++ b/utils/restore-from-old.py
@@ -12,7 +12,8 @@ from tarjan import tarjan
 import kn.leden.entities as Es
 import kn.subscriptions.entities as subscr_Es
 import kn.moderation.entities as mod_Es
-from kn.settings import DT_MIN, DT_MAX
+from kn.base.conf import from_settings_import
+from_settings_import("DT_MIN", "DT_MAX", globals())
 from kn.utils.giedo.db import update_db
 
 def main(data):

--- a/utils/set-photo.py
+++ b/utils/set-photo.py
@@ -4,7 +4,7 @@ import _import
 from common import *
 from kn.leden.models import OldKnUser
 from django.core.files.storage import default_storage
-from kn.settings import SMOELEN_PHOTOS_PATH
+from django.conf import settings
 from os import path
 import sys
 import subprocess
@@ -12,7 +12,7 @@ import subprocess
 def main(username, photo):
     user = OldKnUser.objects.get(username=username)
     subprocess.call(['convert', '-resize', '200x', photo,
-            "jpg:%s.jpg" % (path.join(SMOELEN_PHOTOS_PATH,
+            "jpg:%s.jpg" % (path.join(settings.SMOELEN_PHOTOS_PATH,
                     user.username))])
 
 if __name__ == '__main__':

--- a/utils/shell.py
+++ b/utils/shell.py
@@ -16,7 +16,8 @@ from kn.leden.mongo import _id, ObjectId
 from kn.leden import giedo
 from kn.leden.date import now
 from kn.utils.mailman import import_mailman
-from kn.settings import DT_MIN, DT_MAX
+from kn.base.conf import from_settings_import
+from_settings_import("DT_MIN", "DT_MAX", globals())
 
 def qrel(who=-1, _with=-1, how=-1, _from=None, until=None):
     """ Queries relations """


### PR DESCRIPTION
Overal wordt `kn.settings` gebruikt in plaats van het aanbevolen `django.conf.settings`.  Er is wel een narigheid: `from django.conf.settings import DT_MIN` werkt niet.