### PR TITLE
Nieuwe subscriptions

### DIFF
--- a/kn/leden/mongo.py
+++ b/kn/leden/mongo.py
@@ -10,6 +10,9 @@ from django.conf import settings
 conn = pymongo.Connection(settings.MONGO_HOST)
 db = conn[settings.MONGO_DB]
 
+class RaceCondition(Exception):
+    pass
+
 def _id(obj):
     if isinstance(obj, ObjectId):
         return obj
@@ -20,12 +23,19 @@ def _id(obj):
     raise ValueError
 
 class SONWrapper(object):
-    def __init__(self, data, collection, parent=None):
+    def __init__(self, data, collection, parent=None, detect_race=False):
+        '''
+            parent:      SONWrapper can be nested. This is the parent.
+            detect_race: Add a _version field which is incremented with each
+                         update to detect (and fail on) race conditions.
+        '''
         self._data = data
         self._collection = collection
         self._parent = parent
+        self._detect_race = detect_race
     def delete(self):
         assert self._data['_id'] is not None
+        # TODO check version
         self._collection.remove({
             '_id': self._data['_id']})
     # We take the keyword argument update_fields to be compatible with
@@ -33,9 +43,19 @@ class SONWrapper(object):
     def save(self, update_fields=NotImplemented):
         if self._parent is None:
             if '_id' in self._data:
-                self._collection.update({
-                    '_id': self._data['_id']}, self._data)
+                if self._detect_race:
+                    self._data['_version'] += 1
+                    result = self._collection.update({
+                        '_id': self._data['_id'],
+                        '_version': self._data['_version']-1}, self._data, w=1)
+                    if result['n'] < 1:
+                        raise RaceCondition('Document was not saved')
+                else:
+                    self._collection.update({
+                        '_id': self._data['_id']}, self._data)
             else:
+                if self._detect_race:
+                    self._data['_version'] = 1
                 self._data['_id'] = self._collection.insert(
                         self._data)
         else:
@@ -45,6 +65,11 @@ class SONWrapper(object):
         if self._parent is None:
             return self._data['_id']
         return self._parent._id
+    @property
+    def _version(self):
+        if self._parent is None:
+            return self._data['_version']
+        return self._parent._version
     def __repr__(self):
         return "<SONWrapper for %s>" % self._id
 

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -25,7 +25,6 @@ ecol = db['events']
 #   "is_official" : false,
 #   "description" : "Beschrijving (in **Markdown**).",
 #   "description_html" : "<p>Beschrijving (in <strong>Markdown</strong>).</p>",
-#   "everyone_can_subscribe_others" : true,
 #   "has_public_subscriptions" : true,
 #   "subscriptions" : [
 #       { "user" : ObjectId("4e6fcc85e60edf3dc0000b9f"),
@@ -132,8 +131,6 @@ class Event(SONWrapper):
     mailBody = son_property(('mailBody',))
     subscribedByOtherMailBody = son_property(('subscribedByOtherMailBody',))
     confirmationMailBody = son_property(('confirmationMailBody',))
-    everyone_can_subscribe_others = son_property(
-            ('everyone_can_subscribe_others',), False)
 
     def __unicode__(self):
         return unicode('%s (%s)' % (self.humanName, self.owner))

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -12,6 +12,42 @@ import kn.leden.entities as Es
 
 ecol = db['events']
 
+# Example of an event
+# ------------------
+# { "_id" : ObjectId("55631d03ed25c3345751714a"),
+#   "humanName" : "Activiteit van de LoCo",
+#   "cost" : "0",
+#   "is_open" : true,
+#   "owner" : ObjectId("4e6fcc85e60edf3dc000006f"),
+#   "is_official" : false,
+#   "description_html" : "<p>Beschrijving van de activiteit (in <strong>Markdown</strong>).</p>",
+#   "mailBody" : "Hallo %(firstName)s,\r\n\r\nJe hebt je aangemeld voor %(eventName)s.\r\n\r\nJe opmerkingen waren:\r\n%(notes)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s",
+#   "description" : "Beschrijving van de activiteit (in **Markdown**).",
+#   "subscriptions" : [
+#       { "user" : ObjectId("4e6fcc85e60edf3dc0000b9f"),
+#         "inviter" : ObjectId("50f29894d4080076aa541de2"),
+#         "inviterNotes" : "foo",
+#         "inviteDate" : ISODate("2015-06-10T19:36:50.352Z"),
+#         "history" : [ { "date" : ISODate("2015-06-10T19:37:01.992Z"),
+#                         "state" : "subscribed",
+#                         "notes" : "bar" } ] },
+#       { "user" : ObjectId("50f29894d4080076aa541de2"),
+#         "history" : [ { "date" : ISODate("2015-06-10T19:37:24.555Z"),
+#                         "state" : "subscribed",
+#                         "notes" : "" } ] },
+#       { "user" : ObjectId("4e6fcc85e60edf3dc00001d4"),
+#         "inviter" : ObjectId("50f29894d4080076aa541de2"),
+#         "inviterNotes" : "",
+#         "inviteDate" : ISODate("2015-06-10T19:37:32.514Z") } ],
+#   "createdBy" : ObjectId("50f29894d4080076aa541de2"),
+#   "date" : ISODate("2015-05-25T00:00:00Z"),
+#   "confirmationMailBody" : "Hallo %(firstName)s,\r\n\r\nJe hebt je aanmelding voor %(eventName)s bevestigd.\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s",
+#   "everyone_can_subscribe_others" : true,
+#   "name" : "loco-activiteit",
+#   "subscribedByOtherMailBody" : "Hallo %(firstName)s,\r\n\r\nJe bent door %(by_firstName)s aangemeld voor %(eventName)s.\r\n\r\n%(by_firstName)s opmerkingen waren:\r\n%(by_notes)s\r\n\r\nOm deze aanmelding te bevestigen, bezoek:\r\n  %(confirmationLink)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s",
+#   "has_public_subscriptions" : true
+# }
+
 def ensure_indices():
     ecol.ensure_index('name', unique=True)
     ecol.ensure_index('owner')

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -192,9 +192,7 @@ class Subscription(SONWrapper):
         return 'inviter' in self._data
     @property
     def inviter(self):
-        if not self.invited:
-            return None
-        return Es.by_id(self._data['inviter'])
+        return Es.by_id(self._data.get('inviter'))
     @property
     def lastMutation(self):
         if not self.history:

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -196,33 +196,33 @@ class Subscription(SONWrapper):
             return None
         return Es.by_id(self._data['inviter'])
     @property
-    def stateObject(self):
+    def lastMutation(self):
         if not self.history:
             return {}
         return self.history[-1]
-    def update_stateObject(self, stateObject):
+    def push_mutation(self, mutation):
         if not self.history:
             self.history = []
-        self.history.append(stateObject)
+        self.history.append(mutation)
     @property
     def state(self):
-        return self.stateObject.get('state')
+        return self.lastMutation.get('state')
     @property
     def subscribed(self):
         return self.state == 'subscribed'
     @property
     def date(self):
         # last change date
-        return self.stateObject.get('date') or self.inviteDate
+        return self.lastMutation.get('date') or self.inviteDate
     @property
     def userNotes(self):
-        return self.stateObject.get('notes')
+        return self.lastMutation.get('notes')
     @property
     def notes(self):
         return self.userNotes or self.inviterNotes
     @property
     def subscriber(self):
-        subscriber = self.stateObject.get('subscriber')
+        subscriber = self.lastMutation.get('subscriber')
         if subscriber is not None:
             return Es.by_id(subscriber)
         return self.user
@@ -230,7 +230,7 @@ class Subscription(SONWrapper):
     def subscribe(self, notes):
         if self.subscribed:
             raise SubscriptionError('User already subscribed')
-        self.update_stateObject({
+        self.push_mutation({
             'state': 'subscribed',
             'notes': notes,
             'date': datetime.datetime.now()})

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -47,6 +47,15 @@ ecol = db['events']
 #   "confirmationMailBody" : "Hallo %(firstName)s,\r\n\r\nJe hebt je aanmelding voor %(eventName)s bevestigd.\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s",
 #   "subscribedByOtherMailBody" : "Hallo %(firstName)s,\r\n\r\nJe bent door %(by_firstName)s aangemeld voor %(eventName)s.\r\n\r\n%(by_firstName)s opmerkingen waren:\r\n%(by_notes)s\r\n\r\nOm deze aanmelding te bevestigen, bezoek:\r\n  %(confirmationLink)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s"
 # }
+#
+# Possible states:
+#   * "subscribed"
+#   * "unsubscribed" (unimplemented)
+#   * "reserve"      (unimplemented)
+# When someone has a subscription but no history that person is only invited,
+# not subscribed.
+#
+# Cost: decimal string how much participating in the event will cost.
 
 class SubscriptionError(Exception):
     pass

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -7,7 +7,7 @@ from django.core.mail import EmailMessage
 from django.core.urlresolvers import reverse
 from django.conf import settings
 
-from kn.leden.mongo import db, SONWrapper, _id, son_property, ObjectId
+from kn.leden.mongo import db, SONWrapper, _id, son_property
 import kn.leden.entities as Es
 
 ecol = db['events']

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -157,6 +157,11 @@ class Event(SONWrapper):
         subscription.invite(inviter, notes)
         return subscription
 
+# A Subscription is the relation between a user and an event. When anything
+# happens between the user and the event (invitation, subscription,
+# unsubscription) a Subscription is created or updated. That means a
+# subscription can also be 'unsubscribed' (see _state).
+# You could also call this an RSVP.
 class Subscription(SONWrapper):
     def __init__(self, data, event):
         super(Subscription, self).__init__(data, ecol, event)

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -92,7 +92,7 @@ class Event(SONWrapper):
         return [s for s in self._subscriptions.values() if s.subscribed]
     @property
     def invitations(self):
-        return filter(lambda s: s.invited and not s.state,
+        return filter(lambda s: s.invited and not s.has_mutations,
                       self._subscriptions.values())
     def get_subscription(self, user, create=False):
         '''
@@ -195,11 +195,14 @@ class Subscription(SONWrapper):
             self.history = []
         self.history.append(mutation)
     @property
-    def state(self):
+    def _state(self):
         return self.lastMutation.get('state')
     @property
+    def has_mutations(self):
+        return self._state is not None
+    @property
     def subscribed(self):
-        return self.state == 'subscribed'
+        return self._state == 'subscribed'
     @property
     def date(self):
         # last change date
@@ -232,7 +235,7 @@ class Subscription(SONWrapper):
                     'owner': self.event.owner.humanName,
                     'notes': notes})
     def invite(self, inviter, notes):
-        assert not self.invited and not self.state
+        assert not self.invited and not self.has_mutations
         self._data['inviter'] = _id(inviter)
         self._data['inviteDate'] = datetime.datetime.now()
         self._data['inviterNotes'] = notes

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -11,7 +11,6 @@ from kn.leden.mongo import db, SONWrapper, _id, son_property, ObjectId
 import kn.leden.entities as Es
 
 ecol = db['events']
-scol = db['event_subscriptions']
 
 def ensure_indices():
     ecol.ensure_index('name', unique=True)

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -15,6 +15,7 @@ ecol = db['events']
 # Example of an event
 # ------------------
 # { "_id" : ObjectId("55631d03ed25c3345751714a"),
+#   "_version" : 1,
 #   "name" : "loco-activiteit",
 #   "humanName" : "Activiteit van de LoCo",
 #   "date" : ISODate("2015-05-25T00:00:00Z"),
@@ -71,7 +72,7 @@ def event_by_id(__id):
 
 class Event(SONWrapper):
     def __init__(self, data):
-        super(Event, self).__init__(data, ecol)
+        super(Event, self).__init__(data, ecol, detect_race=True)
         self._subscriptions = {str(d['user']): Subscription(d, self)
                                for d in data.get('subscriptions', [])}
     name = son_property(('name',))

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -15,14 +15,18 @@ ecol = db['events']
 # Example of an event
 # ------------------
 # { "_id" : ObjectId("55631d03ed25c3345751714a"),
+#   "name" : "loco-activiteit",
 #   "humanName" : "Activiteit van de LoCo",
-#   "cost" : "0",
+#   "date" : ISODate("2015-05-25T00:00:00Z"),
+#   "cost" : "3",
 #   "is_open" : true,
+#   "createdBy" : ObjectId("50f29894d4080076aa541de2"),
 #   "owner" : ObjectId("4e6fcc85e60edf3dc000006f"),
 #   "is_official" : false,
-#   "description_html" : "<p>Beschrijving van de activiteit (in <strong>Markdown</strong>).</p>",
-#   "mailBody" : "Hallo %(firstName)s,\r\n\r\nJe hebt je aangemeld voor %(eventName)s.\r\n\r\nJe opmerkingen waren:\r\n%(notes)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s",
-#   "description" : "Beschrijving van de activiteit (in **Markdown**).",
+#   "description" : "Beschrijving (in **Markdown**).",
+#   "description_html" : "<p>Beschrijving (in <strong>Markdown</strong>).</p>",
+#   "everyone_can_subscribe_others" : true,
+#   "has_public_subscriptions" : true,
 #   "subscriptions" : [
 #       { "user" : ObjectId("4e6fcc85e60edf3dc0000b9f"),
 #         "inviter" : ObjectId("50f29894d4080076aa541de2"),
@@ -39,13 +43,9 @@ ecol = db['events']
 #         "inviter" : ObjectId("50f29894d4080076aa541de2"),
 #         "inviterNotes" : "",
 #         "inviteDate" : ISODate("2015-06-10T19:37:32.514Z") } ],
-#   "createdBy" : ObjectId("50f29894d4080076aa541de2"),
-#   "date" : ISODate("2015-05-25T00:00:00Z"),
+#   "mailBody" : "Hallo %(firstName)s,\r\n\r\nJe hebt je aangemeld voor %(eventName)s.\r\n\r\nJe opmerkingen waren:\r\n%(notes)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s",
 #   "confirmationMailBody" : "Hallo %(firstName)s,\r\n\r\nJe hebt je aanmelding voor %(eventName)s bevestigd.\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s",
-#   "everyone_can_subscribe_others" : true,
-#   "name" : "loco-activiteit",
-#   "subscribedByOtherMailBody" : "Hallo %(firstName)s,\r\n\r\nJe bent door %(by_firstName)s aangemeld voor %(eventName)s.\r\n\r\n%(by_firstName)s opmerkingen waren:\r\n%(by_notes)s\r\n\r\nOm deze aanmelding te bevestigen, bezoek:\r\n  %(confirmationLink)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s",
-#   "has_public_subscriptions" : true
+#   "subscribedByOtherMailBody" : "Hallo %(firstName)s,\r\n\r\nJe bent door %(by_firstName)s aangemeld voor %(eventName)s.\r\n\r\n%(by_firstName)s opmerkingen waren:\r\n%(by_notes)s\r\n\r\nOm deze aanmelding te bevestigen, bezoek:\r\n  %(confirmationLink)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s"
 # }
 
 class SubscriptionError(Exception):

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -48,6 +48,9 @@ ecol = db['events']
 #   "has_public_subscriptions" : true
 # }
 
+class SubscriptionError(Exception):
+    pass
+
 def ensure_indices():
     ecol.ensure_index('name', unique=True)
     ecol.ensure_index('owner')
@@ -214,7 +217,7 @@ class Subscription(SONWrapper):
 
     def subscribe(self, notes):
         if self.subscribed:
-            raise ValueError('User already subscribed')
+            raise SubscriptionError('User already subscribed')
         self.update_stateObject({
             'state': 'subscribed',
             'notes': notes,
@@ -229,7 +232,7 @@ class Subscription(SONWrapper):
                     'notes': notes})
     def invite(self, inviter, notes):
         if self.invited or self.state:
-            raise ValueError('Cannot invite user')
+            raise SubscriptionError('Cannot invite user')
         self._data['inviter'] = _id(inviter)
         self._data['inviteDate'] = datetime.datetime.now()
         self._data['inviterNotes'] = notes

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -95,7 +95,7 @@ class Event(SONWrapper):
         return Es.by_id(self._data['createdBy'])
     @property
     def subscriptions(self):
-        return filter(lambda s: s.subscribed, self._subscriptions.values())
+        return [s for s in self._subscriptions.values() if s.subscribed]
     @property
     def invitations(self):
         return filter(lambda s: s.invited and not s.state,

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -42,9 +42,8 @@ ecol = db['events']
 #         "inviter" : ObjectId("50f29894d4080076aa541de2"),
 #         "inviterNotes" : "",
 #         "inviteDate" : ISODate("2015-06-10T19:37:32.514Z") } ],
-#   "mailBody" : "Hallo %(firstName)s,\r\n\r\nJe hebt je aangemeld voor %(eventName)s.\r\n\r\nJe opmerkingen waren:\r\n%(notes)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s",
-#   "confirmationMailBody" : "Hallo %(firstName)s,\r\n\r\nJe hebt je aanmelding voor %(eventName)s bevestigd.\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s",
-#   "subscribedByOtherMailBody" : "Hallo %(firstName)s,\r\n\r\nJe bent door %(by_firstName)s aangemeld voor %(eventName)s.\r\n\r\n%(by_firstName)s opmerkingen waren:\r\n%(by_notes)s\r\n\r\nOm deze aanmelding te bevestigen, bezoek:\r\n  %(confirmationLink)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s"
+#   "subscribedMailBody" : "Hallo %(firstName)s,\r\n\r\nJe hebt je aangemeld voor %(eventName)s.\r\n\r\nJe opmerkingen waren:\r\n%(notes)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s",
+#   "invitedMailBody" : "Hallo %(firstName)s,\r\n\r\nJe bent door %(by_firstName)s aangemeld voor %(eventName)s.\r\n\r\n%(by_firstName)s opmerkingen waren:\r\n%(by_notes)s\r\n\r\nOm deze aanmelding te bevestigen, bezoek:\r\n  %(confirmationLink)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s"
 # }
 #
 # Possible states:
@@ -125,9 +124,8 @@ class Event(SONWrapper):
     is_official = son_property(('is_official',), True)
     has_public_subscriptions = son_property(('has_public_subscriptions',),
                                     False)
-    mailBody = son_property(('mailBody',))
-    subscribedByOtherMailBody = son_property(('subscribedByOtherMailBody',))
-    confirmationMailBody = son_property(('confirmationMailBody',))
+    subscribedMailBody = son_property(('subscribedMailBody',))
+    invitedMailBody = son_property(('invitedMailBody',))
 
     def __unicode__(self):
         return unicode('%s (%s)' % (self.humanName, self.owner))
@@ -229,7 +227,7 @@ class Subscription(SONWrapper):
         self.save()
         self.send_notification(
                 "Aanmelding %s" % self.event.humanName,
-                 self.event.mailBody % {
+                 self.event.subscribedMailBody % {
                     'firstName': self.user.first_name,
                     'eventName': self.event.humanName,
                     'owner': self.event.owner.humanName,
@@ -242,7 +240,7 @@ class Subscription(SONWrapper):
         self.save()
         self.send_notification(
                 "Uitnodiging " + self.event.humanName,
-                 self.event.subscribedByOtherMailBody % {
+                 self.event.invitedMailBody % {
                     'firstName': self.user.first_name,
                     'by_firstName': inviter.first_name,
                     'by_notes': notes,

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -84,7 +84,6 @@ class Event(SONWrapper):
     name = son_property(('name',))
     humanName = son_property(('humanName',))
     date = son_property(('date',))
-    description = son_property(('description',))
     @property
     def id(self):
         return str(self._data['_id'])
@@ -103,6 +102,9 @@ class Event(SONWrapper):
                       self._subscriptions.values())
     def get_subscription(self, user):
         return self._subscriptions.get(str(_id(user)))
+    @property
+    def description(self):
+        return self._data['description']
     @property
     def description_html(self):
         return self._data.get('description_html',

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -1,8 +1,10 @@
 import decimal
+import datetime
 
 from django.db.models import permalink
 from django.utils.html import escape, linebreaks
 from django.core.mail import EmailMessage
+from django.core.urlresolvers import reverse
 from django.conf import settings
 
 from kn.leden.mongo import db, SONWrapper, _id, son_property, ObjectId
@@ -15,16 +17,10 @@ def ensure_indices():
     ecol.ensure_index('name', unique=True)
     ecol.ensure_index('owner')
     ecol.ensure_index('date')
-    scol.ensure_index('user')
-    scol.ensure_index('date')
-    scol.ensure_index('event')
 
 def all_events():
     for m in ecol.find().sort('date'):
         yield Event(m)
-def all_subscriptions():
-    for m in scol.find():
-        yield Subscription(m)
 
 def event_by_name(name):
     tmp = ecol.find_one({'name': name})
@@ -32,51 +28,40 @@ def event_by_name(name):
 def event_by_id(__id):
     tmp = ecol.find_one({'_id': _id(__id)})
     return None if tmp is None else Event(tmp)
-def subscription_by_id(__id):
-    tmp =  scol.find_one({'_id': _id(__id)})
-    return None if tmp is None else Subscription(tmp)
 
 class Event(SONWrapper):
     def __init__(self, data):
         super(Event, self).__init__(data, ecol)
+        self._subscriptions = {str(d['user']): Subscription(d, self)
+                               for d in data.get('subscriptions', [])}
+    name = son_property(('name',))
+    humanName = son_property(('humanName',))
+    date = son_property(('date',))
+    description = son_property(('description',))
     @property
     def id(self):
         return str(self._data['_id'])
-    @property
-    def date(self):
-        return self._data.get('date', None)
     @property
     def owner(self):
         return Es.by_id(self._data['owner'])
     @property
     def createdBy(self):
         return Es.by_id(self._data['createdBy'])
-
-    def get_subscriptions(self):
-        for s in scol.find({ 'event': self._data['_id']}).sort('date'):
-            yield Subscription(s)
-    def get_subscription_of(self, user):
-        d = scol.find_one({
-            'event': self._data['_id'],
-            'user': _id(user)})
-        if d is None:
-            return None
-        return Subscription(d)
     @property
-    def description(self):
-        return self._data['description']
+    def subscriptions(self):
+        return filter(lambda s: s.subscribed, self._subscriptions.values())
+    @property
+    def invitations(self):
+        return filter(lambda s: s.invited and not s.state,
+                      self._subscriptions.values())
+    def subscription(self, user):
+        return self._subscriptions.get(str(_id(user)))
     @property
     def description_html(self):
         return self._data.get('description_html',
                 linebreaks(escape(self._data['description'])))
         # Let wel: 'description' is een *fallback*, het is niet de bedoeling dat
         # deze bij nieuwe actieviteitne nog gebruikt wordt
-    @property
-    def name(self):
-        return self._data['name']
-    @property
-    def humanName(self):
-        return self._data['humanName']
     @property
     def cost(self):
         return decimal.Decimal(self._data['cost'])
@@ -111,48 +96,124 @@ class Event(SONWrapper):
         return self.owner == user or \
             str(self.owner.name) in user.cached_groups_names or \
                'secretariaat' in user.cached_groups_names
-    def has_debit_access(self, user):
-        return 'penningmeester' in user.cached_groups_names or \
-               'secretariaat' in user.cached_groups_names
+
+    def subscribe(self, user, notes):
+        subscription = self.create_subscription(user)
+        subscription.subscribe(notes)
+        return subscription
+    def invite(self, user, notes, inviter):
+        subscription = self.create_subscription(user)
+        subscription.invite(inviter, notes)
+        return subscription
+    def create_subscription(self, user):
+        ''' Create or return Subscription for user '''
+        subscription = self.subscription(user)
+        if subscription:
+            return subscription
+        if 'subscriptions' not in self._data:
+            self._data['subscriptions'] = []
+        d = {'user': _id(user)}
+        self._data['subscriptions'].append(d)
+        self._subscriptions[str(d['user'])] = Subscription(d, self)
+        return self.subscription(user)
 
 class Subscription(SONWrapper):
-    def __init__(self, data):
-        super(Subscription, self).__init__(data, scol)
+    def __init__(self, data, event):
+        super(Subscription, self).__init__(data, ecol, event)
+        self.event = event
+
+    inviterNotes = son_property(('inviterNotes',))
+    inviteDate = son_property(('inviteDate',))
+    date = son_property(('date',))
+    history = son_property(('history',),)
+
+    def __unicode__(self):
+        return unicode(u"<Subscription(%s for %s)>" % (self.user.humanName,
+                        self.event.humanName))
+
     @property
     def id(self):
         return str(self._data['_id'])
     @property
-    def date(self):
-        return self._data.get('date', None)
-    @property
-    def event(self):
-        return Event(event_by_id(self._data['event']))
-    @property
     def user(self):
         return Es.by_id(self._data['user'])
-
-    def __unicode__(self):
-        return unicode(u"%s for %s" % (self.user.humanName,
-                        self.event.humanName))
-    def get_debit(self):
-        return decimal.Decimal(self._data['debit'])
-    def set_debit(self, v):
-        self._data['debit'] = str(v)
-    debit = property(get_debit, set_debit)
     @property
-    def subscribedBy(self):
-        if not 'subscribedBy' in self._data:
+    def invited(self):
+        return 'inviter' in self._data
+    @property
+    def inviter(self):
+        if not self.invited:
             return None
-        return Es.by_id(self._data['subscribedBy'])
-    userNotes = son_property(('userNotes',), None)
-    confirmed = son_property(('confirmed',), True)
-    subscribedBy_notes = son_property(('subscribedBy_notes',))
-    dateConfirmed = son_property(('dateConfirmed',))
+        return Es.by_id(self._data['inviter'])
+    @property
+    def stateObject(self):
+        if not self.history:
+            return {}
+        return self.history[-1]
+    def update_stateObject(self, stateObject):
+        if not self.history:
+            self.history = []
+        self.history.append(stateObject)
+    @property
+    def state(self):
+        return self.stateObject.get('state')
+    @property
+    def subscribed(self):
+        return self.state == 'subscribed'
+    @property
+    def date(self):
+        # last change date
+        return self.stateObject.get('date') or self.inviteDate
+    @property
+    def userNotes(self):
+        return self.stateObject.get('notes')
+    @property
+    def notes(self):
+        return self.userNotes or self.inviterNotes
+    @property
+    def subscriber(self):
+        subscriber = self.stateObject.get('subscriber')
+        if subscriber is not None:
+            return Es.by_id(subscriber)
+        return self.user
+
+    def subscribe(self, notes):
+        if self.subscribed:
+            raise ValueError('User already subscribed')
+        self.update_stateObject({
+            'state': 'subscribed',
+            'notes': notes,
+            'date': datetime.datetime.now()})
+        self.save()
+        self.send_notification(
+                "Aanmelding %s" % self.event.humanName,
+                 self.event.mailBody % {
+                    'firstName': self.user.first_name,
+                    'eventName': self.event.humanName,
+                    'owner': self.event.owner.humanName,
+                    'notes': notes})
+    def invite(self, inviter, notes):
+        if self.invited or self.state:
+            raise ValueError('Cannot invite user')
+        self._data['inviter'] = _id(inviter)
+        self._data['inviteDate'] = datetime.datetime.now()
+        self._data['inviterNotes'] = notes
+        self.save()
+        self.send_notification(
+                "Uitnodiging " + self.event.humanName,
+                 self.event.subscribedByOtherMailBody % {
+                    'firstName': self.user.first_name,
+                    'by_firstName': inviter.first_name,
+                    'by_notes': notes,
+                    'eventName': self.event.humanName,
+                    'confirmationLink': (settings.BASE_URL +
+                            reverse('event-detail', args=(self.event.name,))),
+                    'owner': self.event.owner.humanName})
 
     def send_notification(self, subject, body):
-        cc = [self.event._data.owner.canonical_full_email]
-        if self.subscribedBy:
-            cc.append(self.subscribedBy.canonical_full_email)
+        cc = [self.event.owner.canonical_full_email]
+        if self.invited:
+            cc.append(self.inviter.canonical_full_email)
         # See RFC5322 for a description of the References and In-Reply-To
         # headers:
         # https://tools.ietf.org/html/rfc5322#section-3.6.4
@@ -164,9 +225,9 @@ class Subscription(SONWrapper):
                 [self.user.canonical_full_email],
                 cc=cc,
                 headers={
-                    'Reply-To': self.event._data.owner.canonical_full_email,
-                    'In-Reply-To': self.event._data.messageId,
-                    'References': self.event._data.messageId,
+                    'Reply-To': self.event.owner.canonical_full_email,
+                    'In-Reply-To': self.event.messageId,
+                    'References': self.event.messageId,
                 },
         )
         email.send()

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -92,7 +92,7 @@ class Event(SONWrapper):
     def invitations(self):
         return filter(lambda s: s.invited and not s.state,
                       self._subscriptions.values())
-    def subscription(self, user):
+    def get_subscription(self, user):
         return self._subscriptions.get(str(_id(user)))
     @property
     def description_html(self):
@@ -145,7 +145,7 @@ class Event(SONWrapper):
         return subscription
     def create_subscription(self, user):
         ''' Create or return Subscription for user '''
-        subscription = self.subscription(user)
+        subscription = self.get_subscription(user)
         if subscription:
             return subscription
         if 'subscriptions' not in self._data:
@@ -153,7 +153,7 @@ class Event(SONWrapper):
         d = {'user': _id(user)}
         self._data['subscriptions'].append(d)
         self._subscriptions[str(d['user'])] = Subscription(d, self)
-        return self.subscription(user)
+        return self.get_subscription(user)
 
 class Subscription(SONWrapper):
     def __init__(self, data, event):

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -18,7 +18,7 @@ ecol = db['events']
 #   "name" : "loco-activiteit",
 #   "humanName" : "Activiteit van de LoCo",
 #   "date" : ISODate("2015-05-25T00:00:00Z"),
-#   "cost" : "3",
+#   "cost" : "3.40",
 #   "is_open" : true,
 #   "createdBy" : ObjectId("50f29894d4080076aa541de2"),
 #   "owner" : ObjectId("4e6fcc85e60edf3dc000006f"),
@@ -54,8 +54,6 @@ ecol = db['events']
 #   * "reserve"      (unimplemented)
 # When someone has a subscription but no history that person is only invited,
 # not subscribed.
-#
-# Cost: decimal string how much participating in the event will cost.
 
 class SubscriptionError(Exception):
     pass

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -54,9 +54,6 @@ ecol = db['events']
 # When someone has a subscription but no history that person is only invited,
 # not subscribed.
 
-class SubscriptionError(Exception):
-    pass
-
 def ensure_indices():
     ecol.ensure_index('name', unique=True)
     ecol.ensure_index('owner')
@@ -221,8 +218,7 @@ class Subscription(SONWrapper):
         return self.user
 
     def subscribe(self, notes):
-        if self.subscribed:
-            raise SubscriptionError('User already subscribed')
+        assert not self.subscribed
         self.push_mutation({
             'state': 'subscribed',
             'notes': notes,
@@ -236,8 +232,7 @@ class Subscription(SONWrapper):
                     'owner': self.event.owner.humanName,
                     'notes': notes})
     def invite(self, inviter, notes):
-        if self.invited or self.state:
-            raise SubscriptionError('Cannot invite user')
+        assert not self.invited and not self.state
         self._data['inviter'] = _id(inviter)
         self._data['inviteDate'] = datetime.datetime.now()
         self._data['inviterNotes'] = notes

--- a/kn/subscriptions/forms.py
+++ b/kn/subscriptions/forms.py
@@ -9,7 +9,7 @@ def get_add_event_form(user, superuser=False):
         humanName = forms.CharField(label='Naam')
         description = forms.CharField(label='Beschrijving',
                 widget=forms.Textarea)
-        mailBody = forms.CharField(label='E-Mail wanneer aangemeld',
+        subscribedMailBody = forms.CharField(label='E-Mail wanneer aangemeld',
             widget=forms.Textarea,
             initial="Hallo %(firstName)s,\n\n"+
                 "Je hebt je aangemeld voor %(eventName)s.\n"+
@@ -19,26 +19,19 @@ def get_add_event_form(user, superuser=False):
                 "\n"+
                 "Met een vriendelijke groet,\n\n"+
                 "%(owner)s")
-        subscribedByOtherMailBody = forms.CharField(
-            label='E-Mail wanneer aangemeld door een ander',
+        invitedMailBody = forms.CharField(
+            label='E-Mail wanneer uitgenodigd',
             widget=forms.Textarea,
             initial="Hallo %(firstName)s,\n\n"+
-                "Je bent door %(by_firstName)s aangemeld "+
+                "Je bent door %(by_firstName)s uitgenodigd "+
                     "voor %(eventName)s.\n"+
                 "\n"+
                 "%(by_firstName)s opmerkingen waren:\n"+
                 "%(by_notes)s\n"+
                 "\n"+
-                "Om deze aanmelding te bevestigen, bezoek:\n"
+                "Om deze uitnodiging te bevestigen, bezoek:\n"
                 "  %(confirmationLink)s\n"+
                 "\n"+
-                "Met een vriendelijke groet,\n\n"+
-                "%(owner)s")
-        confirmationMailBody = forms.CharField(
-            label='E-Mail wanneer aanmelding is bevestigd',
-            widget=forms.Textarea,
-            initial="Hallo %(firstName)s,\n\n"+
-                "Je hebt je aanmelding voor %(eventName)s bevestigd.\n\n"+
                 "Met een vriendelijke groet,\n\n"+
                 "%(owner)s")
         cost = forms.DecimalField(label='Kosten')

--- a/kn/subscriptions/forms.py
+++ b/kn/subscriptions/forms.py
@@ -46,8 +46,6 @@ def get_add_event_form(user, superuser=False):
         owner = EntityChoiceField(label="Eigenaar")
         has_public_subscriptions = forms.BooleanField(required=False,
                 label='Inschrijvingen openbaar')
-        everyone_can_subscribe_others = forms.BooleanField(required=False,
-                label='Iedereen kan iedereen uitnodigen')
     return AddEventForm
 
 # vim: et:sta:bs=2:sw=4:

--- a/kn/subscriptions/forms.py
+++ b/kn/subscriptions/forms.py
@@ -47,7 +47,7 @@ def get_add_event_form(user, superuser=False):
         has_public_subscriptions = forms.BooleanField(required=False,
                 label='Inschrijvingen openbaar')
         everyone_can_subscribe_others = forms.BooleanField(required=False,
-                label='Iedereen kan iedereen inschrijven')
+                label='Iedereen kan iedereen uitnodigen')
     return AddEventForm
 
 # vim: et:sta:bs=2:sw=4:

--- a/kn/subscriptions/media/event_detail.css
+++ b/kn/subscriptions/media/event_detail.css
@@ -1,0 +1,13 @@
+
+form.subscribe {
+	overflow: hidden; /* clearfix */
+}
+form.subscribe textarea {
+	float: left;
+	margin-right: 5px;
+}
+
+li blockquote {
+	margin-top: 0;
+	margin-bottom: 0;
+}

--- a/kn/subscriptions/templates/subscriptions/event_detail.html
+++ b/kn/subscriptions/templates/subscriptions/event_detail.html
@@ -1,6 +1,11 @@
 {% extends "leden/base.html" %}
 {% load base %}
 
+{% block styles %}
+{{ block.super }}
+<link rel="stylesheet" href="{{ MEDIA_URL }}subscriptions/event_detail.css" />
+{% endblock styles %}
+
 {% block head %}
 {{ block.super }}
 <script type="text/javascript">
@@ -15,26 +20,6 @@ close_event = function() {
                 return;
         _api({'action': 'close-event',
                    'id': '{{ object.id }}' },
-                        function(d) {
-                if(d.success) window.location.reload();
-                if(d.error) alert(d.error);
-        });
-};
-
-confirm_subscription = function() {
-        _api({'action': 'confirm-subscription',
-              'id': '{{ object.id }}',
-              'notes': $('#notes').text()},
-                        function(d) {
-                if(d.success) window.location.reload();
-                if(d.error) alert(d.error);
-        });
-};
-
-change_debit = function(id) {
-        _api({'action': 'change-debit',
-                   'id': id,
-                   'debit': prompt("Nieuw debet")},
                         function(d) {
                 if(d.success) window.location.reload();
                 if(d.error) alert(d.error);
@@ -65,11 +50,6 @@ copy_emailaddresses_to_clipboard = function() {
 {% endblock %}
 
 {% block body %}
-{% if subscription %}
-{% if subscription.confirmed %}
-<div class="message">Je bent aangemeld.</div>
-{% endif %}{# subscription.confirmed #}
-{% endif %}{# subscription #}
 <h1>{{ object.humanName }}</h1>
 <div id="subscription-description">
 {{ object.description_html|safe }}
@@ -90,98 +70,100 @@ copy_emailaddresses_to_clipboard = function() {
 	{% endif %}
 </dl>
 
-{% if object.is_open and has_write_access %}
-<button onclick="close_event()">Sluit inschrijvingen</button> –
-<a href="{% url "event-edit" edit=object.name %}">Bewerk activiteit</a>
-{% endif %}{# object.is_open and has_write_access #}
+{% if subscription.subscribed %}
+<div class="message">Je bent aangemeld.</div>
+{% endif %}{# subscription.subscribed #}
 
-{% if not subscription or may_subscribe_others or not subscription.confirmed %}
+{% if may_subscribe_others or not subscription.subscribed %}
 {% if object.is_open %}
-<form method="post" action="">
-        {% if subscription and not subscription.confirmed %}
-        <p>Je bent door
-        <a href="{{ subscription.subscribedBy.get_absolute_url }}"
-                >{{ subscription.subscribedBy.full_name }}</a>
-        aangemeld, maar hebt dit nog niet bevestigd.</p>
-        {% endif %}{# subscription and not subscription.confirmed #}
+<form class="subscribe" method="POST" action="">
+        {% csrf_token %}
+        {% if subscription.invited and not subscription.state %}
+        <div class="message">Je bent door
+        <a href="{{ subscription.inviter.get_absolute_url }}"
+                >{{ subscription.inviter.full_name }}</a>
+        uitgenodigd.</div>
+        {% endif %}{# subscription.invited and not subscription.state #}
         <!--[if lte IE 9]>
         Opmerkingen:<br/>
         <![endif]-->
-        <textarea class="default" name="notes"
-                style="width: 200px; height: 70px;"
-                placeholder="Opmerkingen"></textarea><br/>
-        {% if subscription and not subscription.confirmed %}
-        <button type="button" onclick="confirm_subscription()"
-                >Aanmelding bevestigen!</button></p>
-        {% endif %}{# subscription and not subscription.confirmed #}
+        <textarea class="default" name="notes" cols="30" rows="4"
+                placeholder="Opmerkingen"></textarea>
+        {% if subscription.invited and not subscription.state %}
+        <input type="submit" name="subscribe"
+                value="Aanmelden bevestigen"/><br/>
+        {% elif not subscription.subscribed %}
+        <input type="submit" name="subscribe" value="Aanmelden"/><br/>
+        {% endif %}
         {% if may_subscribe_others %}
-        <select name="who">
-        {% for u in users %}
-        <option value="{{ u.id }}"
-                {% if u == user and not subscription %}
-                selected="true"
-                {% endif %}{# u == user #}
-                >{{ u.full_name }}</option>
-        {% endfor %}{# u in users #}
-        <input type="submit" value="aanmelden!" />
-        </select>
-        {% else %}{# may_subscribe_others #}
-        {% if not subscription %}
-	<input type="submit" value="{{ user.full_name }} aanmelden!" /> 
-        {% endif %}{# not subscription #}
-        {% endif %}{# may_subscribe_others #}
-	{% csrf_token %}
-</form>
-{% else %}{# object.is_open #}
-<p><em>Je kunt je niet meer aanmelden.</em></p>
-{% endif %}{# object.is_open #}
-{% endif %}{# not subscription or may_subscribe_others or not subscription.confirmed#}
+        <div>
+                <select name="who">
+                {% for u in users %}
+                <option value="{{ u.id }}">{{ u.full_name }}</option>
+                {% endfor %}{# u in users #}
+                </select>
+                <input type="submit" name="invite" value="Uitnodigen" />
+        </div>
+        {% endif %}
+</div>
+{% endif %}
+{% endif %}
 
-{% if has_read_access or has_debit_access or object.has_public_subscriptions %}
-	<h2>Aanmeldingen ({{ subscrlist_count }})</h2>
-{% if has_debit_access %}
-	<p>Er staan nog {{ subscrcount_debit }} betalingen open.</p>
-{% endif %}{# has_debit_access #}
-	<ul>
-	{% for subscr in subscrlist %}
-	<li><a href="{{ subscr.user.get_absolute_url }}"
-                >{{ subscr.user.full_name }}</a>
-                {% if has_debit_access or has_read_access %}
-                [debet: &euro;
-                {{ subscr.debit }}
-                {% endif %}{# has_debit_access or has_read_access #}
-                {% if has_debit_access %}
-                <button onclick="change_debit('{{ subscr.id }}')"
-                        >wijzig</button
-                >{% endif %}{# has_debit_access #}
-                {% if has_debit_access or has_read_access %}
-                        ]
-                {% endif %}{# has_debit_access or has_read_access #}
-                {% if subscr.date %}
-                        <small>{{ subscr.date.date }}</small>
-                {% endif %}{# subscr.date #}</li>
-                {% if subscr.subscribedBy %}
-                aangemeld door
-                <a href="{{ subscr.subscribedBy.get_absolute_url }}"
-                        >{{ subscr.subscribedBy.full_name }}</a>
-                {% if subscr.subscribedBy_notes %}
-                <blockquote>{{ subscr.subscribedBy_notes }}</blockquote>
-                {% endif %}{# subscr.subscribedBy_notes #}
-                {% if subscr.confirmed %}
-                bevestigd op {{ subscr.dateConfirmed.date }}
-                {% else %}{# subscr.confirmed #}
-                nog onbevestigd
-                {% endif %}{# subscr.confirmed #}
-                {% endif %}{# subscr.subscribedBy #}
-                {% if has_read_access %}
-                {% if subscr.userNotes %}
-                <blockquote>{{ subscr.userNotes }}</blockquote>
-                {% endif %}
-                {% endif %}{# has_read_access #}
-	{% endfor %}
-	</ul>
+{% if object.is_open and has_write_access %}
+<div>
+        <button onclick="close_event()">Sluit inschrijvingen</button> –
+        <a href="{% url "event-edit" edit=object.name %}">Bewerk activiteit</a>
+</div>
+{% endif %}{# object.is_open and has_write_access #}
+
+{% if has_read_access or object.has_public_subscriptions %}
         <button onclick="copy_emailaddresses_to_clipboard()">
                 Toon e-mail adressen van de ingeschrevenen
         </button>
-{% endif %}{# has_read_access or has_debit_access or object.has_public_subscriptions#}
+	<h2>Aanmeldingen ({{ subscriptions|length }})</h2>
+	<ul>
+	{% for subscr in subscriptions %}
+	<li><a href="{{ subscr.user.get_absolute_url }}"
+                >{{ subscr.user.full_name }}</a>
+                {% if subscr.date %}
+                        <small>{{ subscr.date.date }}</small>
+                {% endif %}{# subscr.date #}<br/>
+                {% if has_read_access %}
+                {% if subscr.userNotes %}
+                <blockquote>{{ subscr.userNotes }}</blockquote>
+                {% endif %}{# subscr.userNotes #}
+                {% endif %}{# has_read_access #}
+                {% if subscr.inviter %}
+                uitgenodigd door
+                <a href="{{ subscr.inviter.get_absolute_url }}"
+                        >{{ subscr.inviter.full_name }}</a>
+                {% if has_read_access %}
+                {% if subscr.inviterNotes %}
+                <blockquote>{{ subscr.inviterNotes }}</blockquote>
+                {% endif %}{# subscr.inviterNotes #}
+                {% endif %}{# has_read_access #}
+                {% endif %}{# subscr.inviter #}
+                </li>
+	{% endfor %}
+	</ul>
+
+        {% if invitations %}
+        <h2>Uitnodigingen ({{ invitations|length }})</h2>
+        <ul>
+        {% for invt in invitations %}
+                <li><a href="{{ invt.user.get_absolute_url }}"
+                       >{{ invt.user.full_name }}</a>
+                <small>{{ invt.inviteDate.date }}</small><br/>
+                uitgenodigd door
+                <a href="{{ invt.inviter.get_absolute_url }}"
+                        >{{ invt.inviter.full_name }}</a>
+                {% if has_read_access %}
+                {% if invt.notes %}
+                <blockquote>{{ invt.notes }}</blockquote>
+                {% endif %}{# invt.notes #}
+                {% endif %}{# has_read_access #}
+        {% endfor %}
+        </ul>
+        {% endif %}
+{% endif %}{# has_read_access or object.has_public_subscriptions#}
 {% endblock %}

--- a/kn/subscriptions/templates/subscriptions/event_detail.html
+++ b/kn/subscriptions/templates/subscriptions/event_detail.html
@@ -130,7 +130,7 @@ copy_emailaddresses_to_clipboard = function() {
                 uitgenodigd door
                 <a href="{{ subscr.inviter.get_absolute_url }}"
                         >{{ subscr.inviter.full_name }}</a>
-                op {{ subscr.inviteDate.date }}<br/>
+                op {{ subscr.inviteDate.date }}
                 {% if has_read_access %}
                 {% if subscr.inviterNotes %}
                 <blockquote>{{ subscr.inviterNotes }}</blockquote>
@@ -151,6 +151,7 @@ copy_emailaddresses_to_clipboard = function() {
                 uitgenodigd door
                 <a href="{{ invt.inviter.get_absolute_url }}"
                         >{{ invt.inviter.full_name }}</a>
+                op {{ invt.inviteDate.date }}
                 {% if has_read_access %}
                 {% if invt.notes %}
                 <blockquote>{{ invt.notes }}</blockquote>

--- a/kn/subscriptions/templates/subscriptions/event_detail.html
+++ b/kn/subscriptions/templates/subscriptions/event_detail.html
@@ -130,6 +130,7 @@ copy_emailaddresses_to_clipboard = function() {
                 uitgenodigd door
                 <a href="{{ subscr.inviter.get_absolute_url }}"
                         >{{ subscr.inviter.full_name }}</a>
+                op {{ subscr.inviteDate.date }}<br/>
                 {% if has_read_access %}
                 {% if subscr.inviterNotes %}
                 <blockquote>{{ subscr.inviterNotes }}</blockquote>

--- a/kn/subscriptions/templates/subscriptions/event_detail.html
+++ b/kn/subscriptions/templates/subscriptions/event_detail.html
@@ -88,10 +88,7 @@ copy_emailaddresses_to_clipboard = function() {
         <![endif]-->
         <textarea class="default" name="notes" cols="30" rows="4"
                 placeholder="Opmerkingen"></textarea>
-        {% if subscription.invited and not subscription.state %}
-        <input type="submit" name="subscribe"
-                value="Aanmelden bevestigen"/><br/>
-        {% elif not subscription.subscribed %}
+        {% if not subscription.subscribed %}
         <input type="submit" name="subscribe" value="Aanmelden"/><br/>
         {% endif %}
         <div>

--- a/kn/subscriptions/templates/subscriptions/event_detail.html
+++ b/kn/subscriptions/templates/subscriptions/event_detail.html
@@ -113,52 +113,12 @@ copy_emailaddresses_to_clipboard = function() {
         <button onclick="copy_emailaddresses_to_clipboard()">
                 Toon e-mail adressen van de ingeschrevenen
         </button>
-	<h2>Aanmeldingen ({{ subscriptions|length }})</h2>
-	<ul>
-	{% for subscr in subscriptions %}
-	<li><a href="{{ subscr.user.get_absolute_url }}"
-                >{{ subscr.user.full_name }}</a>
-                {% if subscr.date %}
-                        <small>{{ subscr.date.date }}</small>
-                {% endif %}{# subscr.date #}<br/>
-                {% if has_read_access %}
-                {% if subscr.userNotes %}
-                <blockquote>{{ subscr.userNotes }}</blockquote>
-                {% endif %}{# subscr.userNotes #}
-                {% endif %}{# has_read_access #}
-                {% if subscr.invited %}
-                uitgenodigd door
-                <a href="{{ subscr.inviter.get_absolute_url }}"
-                        >{{ subscr.inviter.full_name }}</a>
-                op {{ subscr.inviteDate.date }}
-                {% if has_read_access %}
-                {% if subscr.inviterNotes %}
-                <blockquote>{{ subscr.inviterNotes }}</blockquote>
-                {% endif %}{# subscr.inviterNotes #}
-                {% endif %}{# has_read_access #}
-                {% endif %}{# subscr.invited #}
-                </li>
-	{% endfor %}
-	</ul>
+        <h2>Aanmeldingen ({{ subscriptions|length }})</h2>
+        {% include "subscriptions/include_list.html" with list=subscriptions %}
 
         {% if invitations %}
         <h2>Uitnodigingen ({{ invitations|length }})</h2>
-        <ul>
-        {% for invt in invitations %}
-                <li><a href="{{ invt.user.get_absolute_url }}"
-                       >{{ invt.user.full_name }}</a>
-                <small>{{ invt.inviteDate.date }}</small><br/>
-                uitgenodigd door
-                <a href="{{ invt.inviter.get_absolute_url }}"
-                        >{{ invt.inviter.full_name }}</a>
-                op {{ invt.inviteDate.date }}
-                {% if has_read_access %}
-                {% if invt.notes %}
-                <blockquote>{{ invt.notes }}</blockquote>
-                {% endif %}{# invt.notes #}
-                {% endif %}{# has_read_access #}
-        {% endfor %}
-        </ul>
+        {% include "subscriptions/include_list.html" with list=invitations %}
         {% endif %}
 {% endif %}{# has_read_access or object.has_public_subscriptions#}
 {% endblock %}

--- a/kn/subscriptions/templates/subscriptions/event_detail.html
+++ b/kn/subscriptions/templates/subscriptions/event_detail.html
@@ -133,7 +133,7 @@ copy_emailaddresses_to_clipboard = function() {
                 <blockquote>{{ subscr.userNotes }}</blockquote>
                 {% endif %}{# subscr.userNotes #}
                 {% endif %}{# has_read_access #}
-                {% if subscr.inviter %}
+                {% if subscr.invited %}
                 uitgenodigd door
                 <a href="{{ subscr.inviter.get_absolute_url }}"
                         >{{ subscr.inviter.full_name }}</a>
@@ -142,7 +142,7 @@ copy_emailaddresses_to_clipboard = function() {
                 <blockquote>{{ subscr.inviterNotes }}</blockquote>
                 {% endif %}{# subscr.inviterNotes #}
                 {% endif %}{# has_read_access #}
-                {% endif %}{# subscr.inviter #}
+                {% endif %}{# subscr.invited #}
                 </li>
 	{% endfor %}
 	</ul>

--- a/kn/subscriptions/templates/subscriptions/event_detail.html
+++ b/kn/subscriptions/templates/subscriptions/event_detail.html
@@ -77,12 +77,12 @@ copy_emailaddresses_to_clipboard = function() {
 {% if object.is_open %}
 <form class="subscribe" method="POST" action="">
         {% csrf_token %}
-        {% if subscription.invited and not subscription.state %}
+        {% if subscription.invited and not subscription.has_mutations %}
         <div class="message">Je bent door
         <a href="{{ subscription.inviter.get_absolute_url }}"
                 >{{ subscription.inviter.full_name }}</a>
         uitgenodigd.</div>
-        {% endif %}{# subscription.invited and not subscription.state #}
+        {% endif %}{# subscription.invited and not subscription.has_mutations #}
         <!--[if lte IE 9]>
         Opmerkingen:<br/>
         <![endif]-->

--- a/kn/subscriptions/templates/subscriptions/event_detail.html
+++ b/kn/subscriptions/templates/subscriptions/event_detail.html
@@ -74,7 +74,6 @@ copy_emailaddresses_to_clipboard = function() {
 <div class="message">Je bent aangemeld.</div>
 {% endif %}{# subscription.subscribed #}
 
-{% if may_subscribe_others or not subscription.subscribed %}
 {% if object.is_open %}
 <form class="subscribe" method="POST" action="">
         {% csrf_token %}
@@ -95,7 +94,6 @@ copy_emailaddresses_to_clipboard = function() {
         {% elif not subscription.subscribed %}
         <input type="submit" name="subscribe" value="Aanmelden"/><br/>
         {% endif %}
-        {% if may_subscribe_others %}
         <div>
                 <select name="who">
                 {% for u in users %}
@@ -104,10 +102,8 @@ copy_emailaddresses_to_clipboard = function() {
                 </select>
                 <input type="submit" name="invite" value="Uitnodigen" />
         </div>
-        {% endif %}
 </div>
-{% endif %}
-{% endif %}
+{% endif %}{# object.is_open #}
 
 {% if object.is_open and has_write_access %}
 <div>

--- a/kn/subscriptions/templates/subscriptions/include_list.html
+++ b/kn/subscriptions/templates/subscriptions/include_list.html
@@ -1,0 +1,26 @@
+	<ul>
+	{% for subscr in list %}
+	<li><a href="{{ subscr.user.get_absolute_url }}"
+		>{{ subscr.user.full_name }}</a>
+		{% if subscr.date %}
+			<small>{{ subscr.date.date }}</small>
+		{% endif %}{# subscr.date #}<br/>
+
+		{% if has_read_access %}{# history #}
+		{% if subscr.userNotes %}
+		<blockquote>{{ subscr.userNotes }}</blockquote>
+		{% endif %}{# subscr.userNotes #}
+
+		{% if subscr.invited %}
+		uitgenodigd door
+		<a href="{{ subscr.inviter.get_absolute_url }}"
+			>{{ subscr.inviter.full_name }}</a>
+		op {{ subscr.inviteDate.date }}
+		{% if subscr.inviterNotes %}
+		<blockquote>{{ subscr.inviterNotes }}</blockquote>
+		{% endif %}{# subscr.inviterNotes #}
+		{% endif %}{# subscr.invited #}
+		{% endif %}{# has_read_access #}
+		</li>
+	{% endfor %}
+	</ul>

--- a/kn/subscriptions/views.py
+++ b/kn/subscriptions/views.py
@@ -46,7 +46,7 @@ def event_detail(request, name):
     if event is None:
         raise Http404
     # Has the user already subscribed?
-    subscription = event.subscription(request.user)
+    subscription = event.get_subscription(request.user)
     # What are our permissions?
     has_read_access = event.has_read_access(request.user)
     has_write_access = event.has_write_access(request.user)
@@ -72,7 +72,7 @@ def event_detail(request, name):
         if not user or not user.is_user:
             raise Http404
         # Is the other already subscribed?
-        if event.subscription(user) is not None:
+        if event.get_subscription(user) is not None:
             messages.error(request, "%s is al aangemeld" % user.full_name)
         else:
             notes = request.POST['notes']
@@ -89,7 +89,7 @@ def event_detail(request, name):
            'has_read_access': has_read_access,
            'has_write_access': has_write_access}
     if may_subscribe_others:
-        users = filter(lambda u: event.subscription(u) is None and \
+        users = filter(lambda u: event.get_subscription(u) is None and \
                                  u != request.user,
                        Es.by_name('leden').get_members())
         users = sorted(users, lambda x,y: cmp(unicode(x.humanName),

--- a/kn/subscriptions/views.py
+++ b/kn/subscriptions/views.py
@@ -162,9 +162,8 @@ def event_new_or_edit(request, edit=None):
                 'description': fd['description'],
                 'description_html': kn.utils.markdown.parser.convert(
                                                 fd['description']),
-                'mailBody': fd['mailBody'],
-                'subscribedByOtherMailBody': fd['subscribedByOtherMailBody'],
-                'confirmationMailBody': fd['confirmationMailBody'],
+                'subscribedMailBody': fd['subscribedMailBody'],
+                'invitedMailBody': fd['invitedMailBody'],
                 'has_public_subscriptions': fd['has_public_subscriptions'],
                 'humanName': fd['humanName'],
                 'createdBy': request.user._id,

--- a/kn/subscriptions/views.py
+++ b/kn/subscriptions/views.py
@@ -80,13 +80,17 @@ def event_detail(request, name):
                              u != request.user,
                    Es.by_name('leden').get_members())
     users.sort(key=lambda u: unicode(u.humanName))
+    subscriptions = event.subscriptions
+    subscriptions.sort(key=lambda s: s.date)
+    invitations = event.invitations
+    invitations.sort(key=lambda i: i.date)
 
     ctx = {'object': event,
            'user': request.user,
            'users': users,
            'subscription': subscription,
-           'subscriptions': event.subscriptions,
-           'invitations': event.invitations,
+           'subscriptions': subscriptions,
+           'invitations': invitations,
            'has_read_access': has_read_access,
            'has_write_access': has_write_access}
     return render_to_response('subscriptions/event_detail.html', ctx,

--- a/kn/subscriptions/views.py
+++ b/kn/subscriptions/views.py
@@ -92,8 +92,7 @@ def event_detail(request, name):
         users = filter(lambda u: event.get_subscription(u) is None and \
                                  u != request.user,
                        Es.by_name('leden').get_members())
-        users = sorted(users, lambda x,y: cmp(unicode(x.humanName),
-                                              unicode(y.humanName)))
+        users.sort(key=lambda u: unicode(u.humanName))
         ctx['users'] = users
     return render_to_response('subscriptions/event_detail.html', ctx,
             context_instance=RequestContext(request))

--- a/kn/subscriptions/views.py
+++ b/kn/subscriptions/views.py
@@ -117,7 +117,7 @@ def _api_get_email_addresses(request):
     if not event:
         raise Http404
     if (not event.has_public_subscriptions and
-            not event.has_read_access(request.user):
+            not event.has_read_access(request.user)):
         raise PermissionDenied
     # XXX We can optimize this query
     return JsonHttpResponse({

--- a/media/subscriptions
+++ b/media/subscriptions
@@ -1,0 +1,1 @@
+../kn/subscriptions/media

--- a/utils/one-shot/2015-05-25-convert-subscriptions.py
+++ b/utils/one-shot/2015-05-25-convert-subscriptions.py
@@ -1,0 +1,55 @@
+import _import
+
+from kn.leden.mongo import db, _id
+
+ecol = db['events']
+scol = db['event_subscriptions']
+
+def main():
+    '''
+    Update the database to use more modern subscription system.
+    WARNING: this throws away the 'debit' fields.
+    WARNING: make a backup first! It is hard to roll back these changes.
+    '''
+    events = ecol.find().sort('date')
+    ecount = 0
+    scount = 0
+    for event in events:
+        ecount += 1
+        print 'Event:', event.get('name')
+        subscriptions = event.get('subscriptions', [])
+        users = {s['user'] for s in subscriptions}
+        for subscription in scol.find({'event': event['_id']}):
+            scount += 1
+            print subscription # DEBUG TODO
+            if subscription['user'] in users:
+                raise ValueError('user already in set')
+            users.add(subscription['user'])
+            subscription2 = {
+                'user': subscription['user']
+            }
+            if 'subscribedBy' in subscription:
+                subscription2['inviter'] = subscription['subscribedBy']
+                subscription2['inviterNotes'] = subscription['subscribedBy_notes']
+                subscription2['inviteDate'] = subscription['date']
+                if 'dateConfirmed' in subscription:
+                    subscription2['history'] = [{
+                        'state': 'subscribed',
+                        'date': subscription['dateConfirmed'],
+                    }]
+            else:
+                subscription2['history'] = [{
+                    'state': 'subscribed',
+                    'date': subscription['date'],
+                }]
+            if 'userNotes' in subscription:
+                subscription2['history'][0]['notes'] = subscription['userNotes']
+            subscriptions.append(subscription2)
+        ecol.update({'_id': event['_id']}, {'$set': {'subscriptions': subscriptions}})
+        scol.remove({'event': event['_id']})
+    print 'Moved %d subscriptions into %d events.' % (scount, ecount)
+
+if __name__ == '__main__':
+    main()
+
+# vim: et:sta:bs=2:sw=4:

--- a/utils/one-shot/2015-05-25-convert-subscriptions.py
+++ b/utils/one-shot/2015-05-25-convert-subscriptions.py
@@ -19,6 +19,8 @@ def main():
         print 'Event:', event.get('name')
         if not 'subscriptions' in event:
             event['subscriptions'] = []
+        if not '_version' in event:
+            event['_version'] = 1
         subscriptions = event['subscriptions']
         users = {s['user'] for s in subscriptions}
         for subscription in scol.find({'event': event['_id']}).sort('date'):

--- a/utils/one-shot/2015-05-25-convert-subscriptions.py
+++ b/utils/one-shot/2015-05-25-convert-subscriptions.py
@@ -17,7 +17,9 @@ def main():
     for event in events:
         ecount += 1
         print 'Event:', event.get('name')
-        subscriptions = event.get('subscriptions', [])
+        if not 'subscriptions' in event:
+            event['subscriptions'] = []
+        subscriptions = event['subscriptions']
         users = {s['user'] for s in subscriptions}
         for subscription in scol.find({'event': event['_id']}):
             scount += 1
@@ -44,7 +46,13 @@ def main():
             if 'userNotes' in subscription:
                 subscription2['history'][0]['notes'] = subscription['userNotes']
             subscriptions.append(subscription2)
-        ecol.update({'_id': event['_id']}, {'$set': {'subscriptions': subscriptions}})
+        if 'mailBody' in event:
+            event['subscribedMailBody'] = event['mailBody']
+            del event['mailBody']
+        if 'subscribedByOtherMailBody' in event:
+            event['invitedMailBody'] = event['subscribedByOtherMailBody']
+            del event['subscribedByOtherMailBody']
+        ecol.update({'_id': event['_id']}, event)
         scol.remove({'event': event['_id']})
     print 'Moved %d subscriptions into %d events.' % (scount, ecount)
 

--- a/utils/one-shot/2015-05-25-convert-subscriptions.py
+++ b/utils/one-shot/2015-05-25-convert-subscriptions.py
@@ -21,7 +21,6 @@ def main():
         users = {s['user'] for s in subscriptions}
         for subscription in scol.find({'event': event['_id']}):
             scount += 1
-            print subscription # DEBUG TODO
             if subscription['user'] in users:
                 raise ValueError('user already in set')
             users.add(subscription['user'])

--- a/utils/one-shot/2015-05-25-convert-subscriptions.py
+++ b/utils/one-shot/2015-05-25-convert-subscriptions.py
@@ -21,10 +21,11 @@ def main():
             event['subscriptions'] = []
         subscriptions = event['subscriptions']
         users = {s['user'] for s in subscriptions}
-        for subscription in scol.find({'event': event['_id']}):
+        for subscription in scol.find({'event': event['_id']}).sort('date'):
             scount += 1
             if subscription['user'] in users:
-                raise ValueError('user already in set')
+                print 'WARNING: duplicate subscription for user:', subscription['user']
+                continue
             users.add(subscription['user'])
             subscription2 = {
                 'user': subscription['user']
@@ -39,10 +40,12 @@ def main():
                         'date': subscription['dateConfirmed'],
                     }]
             else:
-                subscription2['history'] = [{
+                mutation = {
                     'state': 'subscribed',
-                    'date': subscription['date'],
-                }]
+                }
+                if 'date' in subscription:
+                    mutation['date'] = subscription['date']
+                subscription2['history'] = [mutation]
             if 'userNotes' in subscription:
                 subscription2['history'][0]['notes'] = subscription['userNotes']
             subscriptions.append(subscription2)


### PR DESCRIPTION
Dit is een grote update aan de subscriptions. Het verandert weinig aan de functionaliteit, maar gebruikt een heel nieuw data model dat toekomstige wijzigingen (zoals uitschrijven bij activiteiten) eenvoudig maakt.

De enige functionele aanpassingen die hier in zitten is dat alles dat met debet te maken heeft is verwijderd en dat 'iemand anders aanmelden' zoveel mogelijk is vervangen door 'iemand anders uitnodigen', want dat is wat het in de praktijk betekent (een onbevestigde aanmelding is geen aanmelding, dus eigenlijk een uitnodiging).

Ik heb het best redelijk getest, maar omdat er maar foutjes in bleven zitten moet het nog eens goed op khandhas getest worden. Bovendien was het conversiescriptje niet heel goed te testen aangezien de database van khandhas maar weinig (test)aanmeldingen bevatte.

Helaas moest het in een keer, deze aanpassing in kleine stukjes doen bleek erg moeilijk en ik vond het niet de moeite.