### PR TITLE
Fix agenda query

### DIFF
--- a/kn/agenda/entities.py
+++ b/kn/agenda/entities.py
@@ -12,7 +12,7 @@ def ensure_indices():
                        ('start', 1)])
 
 def events(agenda=None, limit=None):
-    query = {'start': {'$gte': datetime.now()}}
+    query = {'end': {'$gte': datetime.now()}}
     if agenda is not None:
         query['agenda'] = agenda
     cursor = acol.find(query).sort('start')


### PR DESCRIPTION
Zie #309.

Ik heb de index niet geüpdatet, want:

1. In mijn installatie wordt die al niet gebruikt (kan ook aan mijn installatie liggen):
    ```
> db.agenda.find({agenda: 'kn'}).explain()
{
        "cursor" : "BasicCursor",
        "isMultiKey" : false,
        "n" : 15,
        "nscannedObjects" : 22,
        "nscanned" : 22,
        "nscannedObjectsAllPlans" : 22,
        "nscannedAllPlans" : 22,
        "scanAndOrder" : false,
        "indexOnly" : false,
        "nYields" : 0,
        "nChunkSkips" : 0,
        "millis" : 0,
        "indexBounds" : {

        },
        "server" : "kndev:27017"
}
```
2. Het zijn maar 22 entities op het moment en het zullen er nooit veel meer dan dat worden, dus of er een index wordt gebruikt maakt echt niet uit.

Hiermee is #309 nog steeds niet helemaal gefixt: activiteiten gaan in de agenda vaak tot 23:59 maar in de praktijk duren ze meestal langer, dus misschien wil je nog een paar uur bij de eindtijd optellen.