### PR TITLE
Zen Photo

### DIFF
--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -218,7 +218,7 @@
             }.bind(this));
         }
         if (c.type == 'foto') {
-          $('a', thumb).attr('href', '#'+c.name);
+          $('a', thumb).attr('href', '#'+encodePath(c.name));
         }
         if (c.visibility === 'hidden') {
           thumb.addClass('hidden');
@@ -344,7 +344,7 @@
       return '';
     }
 
-    return hash.substr(1);
+    return decodeURIComponent(hash.substr(1));
   };
 
   KNF.prototype.onhashchange = function() {

--- a/kn/fotos/views.py
+++ b/kn/fotos/views.py
@@ -17,6 +17,7 @@ from django.contrib.auth.views import redirect_to_login
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.http import Http404, HttpResponse, HttpResponseNotModified, QueryDict
+from django.utils.encoding import filepath_to_uri
 
 from kn.fotos.forms import CreateEventForm, getMoveFotosForm, list_events
 from kn.leden import giedo
@@ -46,6 +47,14 @@ def fotos(request, path=''):
     album = fEs.by_path(path)
     if album is None:
         raise Http404
+
+    if album._type != 'album':
+        # This is a photo, not an album.
+        # Backwards compatibility, probably to Zen Photo.
+        url = reverse('fotos', kwargs={'path':album.path}) \
+                + '#'+filepath_to_uri(album.name)
+        return redirect(url, permanent=True)
+
     user = request.user if request.user.is_authenticated() else None
 
     if not album.may_view(user) and user is None:

--- a/kn/fotos/views.py
+++ b/kn/fotos/views.py
@@ -46,6 +46,16 @@ def fotos(request, path=''):
 
     album = fEs.by_path(path)
     if album is None:
+        bits = path.rsplit('/', 1)
+        if len(bits) == 2:
+            path = bits[0]
+            name = bits[1].replace('+', ' ')
+            entity = fEs.by_path_and_name(path, name)
+            if entity is not None:
+                # Zen Photo used + signs in the filename part of the URL.
+                url = reverse('fotos', kwargs={'path':path}) \
+                        + '#'+filepath_to_uri(name)
+                return redirect(url, permanent=True)
         raise Http404
 
     if album._type != 'album':


### PR DESCRIPTION
Oude linkjes in het fotoboek hebben nog een andere structuur, ik vermoed uit de tijd van Zen Photo.

De laatste commit is misschien minder hard nodig. Het is een work-around voor de inconsistente en deels incorrecte escape karakters van Zen Photo voor spaties (`+` voor bestandsnamen en `%20` voor directories).

Getest op khandhas. De links in de mail verwijzen nu naar de pagina met die foto. Links naar foto's waar spaties in zitten blijven werken.