### PR TITLE
Zoek op tags in het fotoalbum

### DIFF
--- a/kn/fotos/entities.py
+++ b/kn/fotos/entities.py
@@ -445,9 +445,8 @@ class FotoAlbum(FotoEntity):
                     continue
                 if user.first_name.lower() in words_set or user.last_name.lower() in words_set:
                     users.append(_id(user))
-            for r in fcol.find({'$and': [query_filter,
-                                         {'tags': {'$in': users}}]}):
-                results.append(r)
+            results.extend(fcol.find({'$and': [query_filter,
+                                               {'tags': {'$in': users}}]}))
 
             # The sort key does some magic.
             # The first element is to sort on type first: albums go first, then

--- a/kn/fotos/entities.py
+++ b/kn/fotos/entities.py
@@ -427,7 +427,7 @@ class FotoAlbum(FotoEntity):
             # operations in MongoDB 2.4, we join and sort them by hand. MongoDB
             # 2.6+ has this feature.
 
-            # Text search (name and description)
+            # Text search (name, title and description)
             results = map(lambda r: r['obj'],
                 db.command('text', 'fotos',
                         search=q,

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -44,6 +44,15 @@
     return "/foto/" + cache + "/" + encodePath(path);
   };
 
+  Foto.prototype.anchor = function() {
+    if ('relpath' in this) {
+      // search result
+      return this.relpath;
+    }
+    // normal photo
+    return this.name;
+  }
+
 
   function KNF(data){
     this.search_query = '';
@@ -115,7 +124,9 @@
               foto.prev = prev;
             }
             prev = foto;
-            this.search_results[foto.name] = foto;
+            foto.relpath = foto.path.substr(
+                this.path.length !== 0 ? this.path.length + 1 : 0);
+            this.search_results[foto.relpath] = foto;
           }
           $.extend(this.people, data.people);
           this.display_fotos();
@@ -216,9 +227,8 @@
               this.change_path(c.path);
               return false;
             }.bind(this));
-        }
-        if (c.type == 'foto') {
-          $('a', thumb).attr('href', '#'+encodePath(c.name));
+        } else {
+          $('a', thumb).attr('href', '#'+encodePath(c.anchor()));
         }
         if (c.visibility === 'hidden') {
           thumb.addClass('hidden');
@@ -389,7 +399,7 @@
       this.apply_url(false);
       return;
     }
-    if (this.get_hash() != foto.name) {
+    if (this.get_hash() != foto.anchor()) {
       this.apply_url(false);
     }
     $('html').addClass('noscroll');
@@ -399,10 +409,10 @@
         .text(foto.title ? foto.title : foto.name);
     if (foto.prev)
       $('.prev', frame)
-          .attr('href', '#'+encodePath(foto.prev.name));
+          .attr('href', '#'+encodePath(foto.prev.anchor()));
     if (foto.next)
       $('.next', frame)
-          .attr('href', '#'+encodePath(foto.next.name));
+          .attr('href', '#'+encodePath(foto.next.anchor()));
     $('.orig', frame)
         .attr('href', foto.full);
     if (foto.description)

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -119,11 +119,13 @@
           var prev = null;
           for (var i=0; i<data.results.length; i++) {
             var foto = new Foto(data.results[i]);
-            if (prev !== null) {
-              prev.next = foto;
-              foto.prev = prev;
+            if (foto.type != 'album') {
+              if (prev !== null) {
+                prev.next = foto;
+                foto.prev = prev;
+              }
+              prev = foto;
             }
-            prev = foto;
             foto.relpath = foto.path.substr(
                 this.path.length !== 0 ? this.path.length + 1 : 0);
             this.search_results[foto.relpath] = foto;

--- a/kn/fotos/utils.py
+++ b/kn/fotos/utils.py
@@ -10,4 +10,51 @@ def resize_proportional(width, height, width_max, height_max=None):
         height *= height_max/height
     return int(round(width)), int(round(height))
 
+def split_words(s):
+    '''
+    Split words like MongoDB does.
+
+    Examples:
+      'abc'           => ['abc']
+      'abc def'       => ['abc', 'def']
+      'abc    def '   => ['abc', 'def']
+      ' "foo   bar "' => ['foo   bar ']
+      ' foo" bar '    => ['foo', ' bar ']
+    '''
+
+    words = []
+    word = ''
+    in_quote = False
+    for c in s:
+        if in_quote:
+            if c == '"':
+                in_quote = False
+                if word:
+                    words.append(word)
+                    word = ''
+            else:
+                word += c
+        else:
+            if c == '"' or c == ' ':
+                if c == '"':
+                    in_quote = True
+                word = word.strip()
+                if word:
+                    words.append(word)
+                    word = ''
+            else:
+                word += c
+
+    if in_quote:
+        if word:
+            words.append(word)
+    else:
+        word = word.strip()
+        if word:
+            words.append(word)
+
+    return words
+
+
+
 # vim: et:sta:bs=2:sw=4:


### PR DESCRIPTION
Hiermee kun je gewoon een naam intypen in het zoekveld (zonder 'tag:' ervoor en zonder de gebruikersnaam te weten) en zoekt hij op tags van mensen. Het is niet de mooiste manier, maar MongoDB 2.4 is hier niet zo makkelijk in (MongoDB 2.6+ heeft een functie om dit mooier te maken).

Verder heb ik ook gezorgd dat albums voor tags gesorteerd worden en nog twee andere bugs gefixt.

Lokaal werkt het, maar ik heb niet zo'n groot testfotoalbum. Ik denk wel dat het gewoon werkt, en het is geen kritiek onderdeel van de site dus als er iets mis is kan ik het op dat moment fixen.