### PR TITLE
Remove 'webcie' and add 'secretariaat' in photo admin groups

### DIFF
--- a/kn/fotos/entities.py
+++ b/kn/fotos/entities.py
@@ -68,7 +68,7 @@ def by_path(p):
 def is_admin(user):
     if user is None:
         return False
-    return bool(user.cached_groups_names & frozenset(('fotocie', 'webcie')))
+    return bool(user.cached_groups_names & frozenset(('fotocie', 'secretariaat')))
 
 def actual_visibility(visibility):
     actual = frozenset(visibility)


### PR DESCRIPTION
Zo zijn de permissies zoals op de rest van de website.
Dit zorgt er ook voor dat er altijd een lid van het bestuur bij het fotoboek kan, dit lijkt me wel zo handig.
WebCie-leden (niet-fotocie leden) doen heel weinig in het fotoboek. Mocht het nodig zijn, kunnen die specifieke leden aan de fotocie worden toegevoegd die dat willen.

Het toevoegen van het secretariaat lijkt me sowieso wenselijk, het verwijderen van de webcie is meer omdat het me grotendeels overbodig lijkt maar vooral dat het niet in lijn is met de permissies op de rest van de website. Natuurlijk kun je over het laatste van mening verschillen...