### PR TITLE
Don't change property when no new value is set (#333)

### DIFF
--- a/kn/leden/media/entity_detail.js
+++ b/kn/leden/media/entity_detail.js
@@ -1,7 +1,9 @@
 'use strict';
 
-function api_set_property(id, property, value) {
-	if (value === null) return;
+
+function promptNewProperty(id, property, message, oldValue) {
+	var value = prompt(message, oldValue);
+	if (!value) return;
 	leden_api({
 			action: 'entity_set_property',
 			id: id,

--- a/kn/leden/templates/leden/entity_base.html
+++ b/kn/leden/templates/leden/entity_base.html
@@ -26,16 +26,16 @@ $(function(){
 <h2>
 	{% if "secretariaat" in user.cached_groups_names %}
 	<button class="change-humanName"
-		onclick="api_set_property('{{ object.id }}', 'humanName',
-				prompt('Wijzig naam', $('.humanName').text()));">Wijzig naam</button>
+		onclick="promptNewProperty('{{ object.id }}', 'humanName',
+				'Wijzig naam', $('.humanName').text());">Wijzig naam</button>
 	{% endif %}{# "secretariaat" in user.cached_groups_names #}
 	<span class="humanName">{{ object.humanName }}</span>
 </h2>
 <p>
 	{% if "secretariaat" in user.cached_groups_names %}
 	<button class="change-description"
-		onclick="api_set_property('{{ object.id }}', 'description',
-				prompt('Nieuwe beschrijving', $('.description').text()));">
+		onclick="promptNewProperty('{{ object.id }}', 'description',
+				'Nieuwe beschrijving', $('.description').text());">
 		Wijzig beschrijving</button>
 	{% endif %}{# "secretariaat" in user.cached_groups_names #}
 	<span class="description">{{ object.description }}</span>


### PR DESCRIPTION
Dit is een fout in de browser. `prompt()` zou `null` moeten retourneren. Bij mij (Chrome) werkt het goed:

> In Safari, if the user clicks Cancel, the function returns an empty string. Therefore, it doesn't differentiate canceling from the user entering an empty string in the textbox.

https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt

Maar hier is een fix (getest in Chrome, niet in Safari).