### PR TITLE
Work around race condition in run-fcgi

### DIFF
--- a/bin/run-fcgi
+++ b/bin/run-fcgi
@@ -10,6 +10,9 @@ rm -f $HOME/fcgi.sock $HOME/fcgi.pid
 
 set -e
 ./manage.py runfcgi socket=$HOME/fcgi.sock umask=002 pidfile=$HOME/fcgi.pid
+while [ ! -e $HOME/fcgi.sock ]; do
+    sleep 0.1
+done
 chgrp interinfra $HOME/fcgi.sock
 
 popd &> /dev/null


### PR DESCRIPTION
Dit bleek nodig bij mij, als ik run-fcgi wil starten via `@reboot` crontab. Normaal gesproken werkt het, maar als de computer druk bezig is (bijvoorbeeld tijdens het opstarten) bestaat fcgi.sock nog niet.