### PR TITLE
Use HTML <select> element for owner when the user is not a superuser

### DIFF
--- a/kn/base/media/base.css
+++ b/kn/base/media/base.css
@@ -523,6 +523,7 @@ form.top-aligned p {
 }
 
 form.top-aligned input,
+form.top-aligned select,
 form.top-aligned textarea {
 	display: block;
 	margin: 2px 0;

--- a/kn/subscriptions/forms.py
+++ b/kn/subscriptions/forms.py
@@ -1,9 +1,22 @@
 from django import forms
 
 from kn.leden.forms import EntityChoiceField
+from kn.leden.mongo import _id
 import kn.leden.entities as Es
 
 import textwrap
+
+def get_allowed_owners(user):
+    '''
+    Get the entities (often groups) that this owner is allowed to use.
+    Does not check for superuser capabilities (which may select any entity).
+    '''
+    # Warning: the actual checking is done in views.event_new_or_edit!
+    comms = Es.by_name('comms')
+    entities = [user] + \
+                [g for g in user.cached_groups if g.has_tag(comms)]
+    return entities
+
 
 def get_add_event_form(user, superuser=False):
     class AddEventForm(forms.Form):
@@ -44,7 +57,12 @@ def get_add_event_form(user, superuser=False):
         date = forms.DateField(label='Datum')
         max_subscriptions = forms.IntegerField(required=False,
                 label='Maximum aantal deelnemers (optioneel)')
-        owner = EntityChoiceField(label="Eigenaar")
+        if superuser:
+            owner = EntityChoiceField(label="Eigenaar")
+        else:
+            owner = forms.ChoiceField(label='Eigenaar',
+                                      choices=[(_id(e), unicode(e.humanName))
+                                               for e in get_allowed_owners(user)])
         has_public_subscriptions = forms.BooleanField(required=False,
                 label='Inschrijvingen openbaar')
     return AddEventForm


### PR DESCRIPTION
This prevents 'permission denied' errors when selecting the wrong owner.

closes #355 
closes #107 