### PR TITLE
Afmelden

### DIFF
--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -28,6 +28,7 @@ ecol = db['events']
 #   "description" : "Beschrijving (in **Markdown**).",
 #   "description_html" : "<p>Beschrijving (in <strong>Markdown</strong>).</p>",
 #   "has_public_subscriptions" : true,
+#   "may_unsubscribe": true,
 #   "subscriptions" : [
 #       { "user" : ObjectId("4e6fcc85e60edf3dc0000b9f"),
 #         "inviter" : ObjectId("50f29894d4080076aa541de2"),
@@ -80,6 +81,7 @@ class Event(SONWrapper):
     name = son_property(('name',))
     humanName = son_property(('humanName',))
     date = son_property(('date',))
+    may_unsubscribe = son_property(('may_unsubscribe',))
     @property
     def id(self):
         return str(self._data['_id'])
@@ -163,7 +165,7 @@ class Event(SONWrapper):
         return self.is_open
     @property
     def can_unsubscribe(self):
-        return self.is_open
+        return self.is_open and self.may_unsubscribe
 
     def subscribe(self, user, notes):
         subscription = self.get_subscription(user, create=True)

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -3,10 +3,10 @@ import datetime
 
 from django.db.models import permalink
 from django.utils.html import escape, linebreaks
-from django.core.mail import EmailMessage
 from django.core.urlresolvers import reverse
 from django.conf import settings
 
+from kn.base.mail import render_then_email
 from kn.leden.mongo import db, SONWrapper, _id, son_property
 import kn.leden.entities as Es
 
@@ -44,10 +44,7 @@ ecol = db['events']
 #       { "user" : ObjectId("4e6fcc85e60edf3dc00001d4"),
 #         "inviter" : ObjectId("50f29894d4080076aa541de2"),
 #         "inviterNotes" : "",
-#         "inviteDate" : ISODate("2015-06-10T19:37:32.514Z") } ],
-#   "subscribedMailBody" : "Hallo %(firstName)s,\r\n\r\nJe hebt je aangemeld voor %(eventName)s.\r\n\r\nJe opmerkingen waren:\r\n%(notes)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s",
-#   "unsubscribedMailBody" : "Hallo %(firstName)s,\r\n\r\nJe hebt je afgemeld voor %(eventName)s.\r\n\r\nJe opmerkingen waren:\r\n%(notes)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s",
-#   "invitedMailBody" : "Hallo %(firstName)s,\r\n\r\nJe bent door %(by_firstName)s aangemeld voor %(eventName)s.\r\n\r\n%(by_firstName)s opmerkingen waren:\r\n%(by_notes)s\r\n\r\nOm deze aanmelding te bevestigen, bezoek:\r\n  %(confirmationLink)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s"
+#         "inviteDate" : ISODate("2015-06-10T19:37:32.514Z") } ]
 # }
 #
 # Possible states:
@@ -133,9 +130,6 @@ class Event(SONWrapper):
     is_official = son_property(('is_official',), True)
     has_public_subscriptions = son_property(('has_public_subscriptions',),
                                     False)
-    subscribedMailBody = son_property(('subscribedMailBody',))
-    unsubscribedMailBody = son_property(('unsubscribedMailBody',))
-    invitedMailBody = son_property(('invitedMailBody',))
 
     def __unicode__(self):
         return unicode('%s (%s)' % (self.humanName, self.owner))
@@ -251,50 +245,32 @@ class Subscription(SONWrapper):
 
     def subscribe(self, notes):
         assert not self.subscribed
-        self.push_mutation({
+        mutation = {
             'state': 'subscribed',
             'notes': notes,
-            'date': datetime.datetime.now()})
+            'date': datetime.datetime.now()}
+        self.push_mutation(mutation)
         self.save()
-        self.send_notification(
-                "Aanmelding %s" % self.event.humanName,
-                 self.event.subscribedMailBody % {
-                    'firstName': self.user.first_name,
-                    'eventName': self.event.humanName,
-                    'owner': self.event.owner.humanName,
-                    'notes': notes})
+        self.send_notification(mutation)
     def unsubscribe(self, notes):
         assert self.subscribed
-        self.push_mutation({
+        mutation = {
             'state': 'unsubscribed',
             'notes': notes,
-            'date': datetime.datetime.now()})
+            'date': datetime.datetime.now()}
+        self.push_mutation(mutation)
         self.save()
-        self.send_notification(
-                "Afmelding %s" % self.event.humanName,
-                 self.event.unsubscribedMailBody % {
-                    'firstName': self.user.first_name,
-                    'eventName': self.event.humanName,
-                    'owner': self.event.owner.humanName,
-                    'notes': notes})
+        self.send_notification(mutation)
     def invite(self, inviter, notes):
         assert not self.invited and not self.has_mutations
         self._data['inviter'] = _id(inviter)
         self._data['inviteDate'] = datetime.datetime.now()
         self._data['inviterNotes'] = notes
         self.save()
-        self.send_notification(
-                "Uitnodiging " + self.event.humanName,
-                 self.event.invitedMailBody % {
-                    'firstName': self.user.first_name,
-                    'by_firstName': inviter.first_name,
-                    'by_notes': notes,
-                    'eventName': self.event.humanName,
-                    'confirmationLink': (settings.BASE_URL +
-                            reverse('event-detail', args=(self.event.name,))),
-                    'owner': self.event.owner.humanName})
+        self.send_notification({'state': 'invited'})
 
-    def send_notification(self, subject, body):
+    def send_notification(self, mutation,
+            template='subscriptions/subscription-notification.mail.html'):
         cc = [self.event.owner.canonical_full_email]
         if self.invited:
             cc.append(self.inviter.canonical_full_email)
@@ -302,18 +278,18 @@ class Subscription(SONWrapper):
         # headers:
         # https://tools.ietf.org/html/rfc5322#section-3.6.4
         # They are used here for proper threading in mail applications.
-        email = EmailMessage(
-                subject,
-                body,
-                'Karpe Noktem Activiteiten <root@karpenoktem.nl>',
-                [self.user.canonical_full_email],
+        render_then_email(template,
+                self.user.canonical_full_email,
+                ctx={
+                    'mutation': mutation,
+                    'subscription': self,
+                    'event': self.event,
+                },
                 cc=cc,
+                reply_to=self.event.owner.canonical_full_email,
                 headers={
-                    'Reply-To': self.event.owner.canonical_full_email,
                     'In-Reply-To': self.event.messageId,
                     'References': self.event.messageId,
-                },
-        )
-        email.send()
+                })
 
 # vim: et:sta:bs=2:sw=4:

--- a/kn/subscriptions/forms.py
+++ b/kn/subscriptions/forms.py
@@ -57,6 +57,8 @@ def get_add_event_form(user, superuser=False):
         owner = EntityChoiceField(label="Eigenaar")
         has_public_subscriptions = forms.BooleanField(required=False,
                 label='Inschrijvingen openbaar')
+        may_unsubscribe = forms.BooleanField(required=False, initial=True,
+                label='Leden mogen zichzelf afmelden')
     return AddEventForm
 
 # vim: et:sta:bs=2:sw=4:

--- a/kn/subscriptions/forms.py
+++ b/kn/subscriptions/forms.py
@@ -21,6 +21,16 @@ def get_add_event_form(user, superuser=False):
                 "\n"+
                 "Met een vriendelijke groet,\n\n"+
                 "%(owner)s")
+        unsubscribedMailBody = forms.CharField(label='E-Mail wanneer afgemeld',
+            widget=forms.Textarea,
+            initial="Hallo %(firstName)s,\n\n"+
+                "Je hebt je afgemeld voor %(eventName)s.\n"+
+                "\n"+
+                "Je opmerkingen waren:\n"+
+                "%(notes)s\n"+
+                "\n"+
+                "Met een vriendelijke groet,\n\n"+
+                "%(owner)s")
         invitedMailBody = forms.CharField(
             label='E-Mail wanneer uitgenodigd',
             widget=forms.Textarea,

--- a/kn/subscriptions/forms.py
+++ b/kn/subscriptions/forms.py
@@ -11,45 +11,6 @@ def get_add_event_form(user, superuser=False):
         humanName = forms.CharField(label='Naam')
         description = forms.CharField(label='Beschrijving',
                 widget=forms.Textarea)
-        subscribedMailBody = forms.CharField(label='E-Mail wanneer aangemeld',
-            widget=forms.Textarea,
-            initial="Hallo %(firstName)s,\n\n"+
-                "Je hebt je aangemeld voor %(eventName)s.\n"+
-                "\n"+
-                "Je opmerkingen waren:\n"+
-                "%(notes)s\n"+
-                "\n"+
-                "Met een vriendelijke groet,\n\n"+
-                "%(owner)s")
-        unsubscribedMailBody = forms.CharField(label='E-Mail wanneer afgemeld',
-            widget=forms.Textarea,
-            initial="Hallo %(firstName)s,\n\n"+
-                "Je hebt je afgemeld voor %(eventName)s.\n"+
-                "\n"+
-                "Je opmerkingen waren:\n"+
-                "%(notes)s\n"+
-                "\n"+
-                "Met een vriendelijke groet,\n\n"+
-                "%(owner)s")
-        invitedMailBody = forms.CharField(
-            label='E-Mail wanneer uitgenodigd',
-            widget=forms.Textarea,
-            initial=textwrap.dedent("""
-                Hallo %(firstName)s,
-
-                Je bent door %(by_firstName)s uitgenodigd voor %(eventName)s.
-
-                %(by_firstName)s opmerkingen waren:
-
-                  %(by_notes)s
-
-                Om je aanmelding te bevestigen, ga naar de volgende pagina
-                en druk op `aanmelden'.
-
-                  %(confirmationLink)s
-
-                %(owner)s
-                """).strip())
         cost = forms.DecimalField(label='Kosten')
         date = forms.DateField(label='Datum')
         max_subscriptions = forms.IntegerField(required=False,

--- a/kn/subscriptions/media/event_detail.css
+++ b/kn/subscriptions/media/event_detail.css
@@ -7,7 +7,8 @@ form.subscribe textarea {
 	margin-right: 5px;
 }
 
-li blockquote {
+blockquote.notes {
 	margin-top: 0;
 	margin-bottom: 0;
+	white-space: pre-line;
 }

--- a/kn/subscriptions/templates/subscriptions/event_detail.html
+++ b/kn/subscriptions/templates/subscriptions/event_detail.html
@@ -57,7 +57,7 @@ var event_object_id = '{{ object.id }}';
     <div class="tabBody" id="tab-subscribe">
         <form class="subscribe" method="POST" action="">
             {% csrf_token %}
-            {% if subscription.subscribed %}
+            {% if subscription.subscribed and object.can_unsubscribe %}
             <div class="message"><strong>Je bent al aangemeld</strong>, maar je
                 kunt je nog afmelden.</div>
             {% elif subscription.invited and not subscription.has_mutations %}
@@ -67,19 +67,19 @@ var event_object_id = '{{ object.id }}';
             uitgenodigd.</div>
             {% endif %}
 
-            {% if object.can_subscribe %}
+            {% if object.can_subscribe and not subscription.subscribed or object.can_unsubscribe and not subscription.unsubscribed %}
             <!--[if lte IE 9]>
             Opmerkingen:<br/>
             <![endif]-->
             <textarea class="default" name="notes" cols="30" rows="4"
                 placeholder="Opmerkingen"></textarea>
-            {% if not subscription.subscribed %}
-            <input type="submit" name="subscribe" value="Aanmelden"/><br/>
-            {% else %}
+            {% if subscription.subscribed %}
             <input type="submit" name="unsubscribe" value="Afmelden"/><br/>
+            {% elif subscription.unsubscribed %}
+            <input type="submit" name="subscribe" value="Aanmelden"/><br/>
             {% endif %}{# subscription.subscribed #}
             {% else %}
-            Je kunt je helaas niet meer aanmelden.
+            Je kunt je helaas niet meer aanmelden of afmelden.
             {% endif %}{# object.can_subscribe #}
         </form>
     </div>

--- a/kn/subscriptions/templates/subscriptions/event_detail.html
+++ b/kn/subscriptions/templates/subscriptions/event_detail.html
@@ -77,9 +77,20 @@ var event_object_id = '{{ object.id }}';
             <input type="submit" name="unsubscribe" value="Afmelden"/><br/>
             {% else %}
             <input type="submit" name="subscribe" value="Aanmelden"/><br/>
+            {% if not object.may_unsubscribe %}
+            (je kunt je daarna niet meer afmelden)<br/>
+            {% endif %}{# object.may_unsubscribe #}
             {% endif %}{# subscription.subscribed #}
             {% else %}
-            Je kunt je helaas niet meer aanmelden of afmelden.
+            {% if not object.is_open %}
+            De activiteit is gesloten, je kunt je niet meer aanmelden of
+            afmelden.
+            {% else %}
+            Je kunt je helaas niet meer aanmelden{% if object.may_unsubscribe %}
+                of afmelden{% endif %}.<br/>
+            {% endif %}{# object.is_open #}
+            Stuur een mailtje naar <a href="mailto:{{ object.owner.canonical_email }}"
+                >{{ object.owner.canonical_email }}</a> voor vragen.
             {% endif %}{# object.can_subscribe #}
         </form>
     </div>

--- a/kn/subscriptions/templates/subscriptions/event_detail.html
+++ b/kn/subscriptions/templates/subscriptions/event_detail.html
@@ -75,7 +75,7 @@ var event_object_id = '{{ object.id }}';
                 placeholder="Opmerkingen"></textarea>
             {% if subscription.subscribed %}
             <input type="submit" name="unsubscribe" value="Afmelden"/><br/>
-            {% elif subscription.unsubscribed %}
+            {% else %}
             <input type="submit" name="subscribe" value="Aanmelden"/><br/>
             {% endif %}{# subscription.subscribed #}
             {% else %}

--- a/kn/subscriptions/templates/subscriptions/event_detail.html
+++ b/kn/subscriptions/templates/subscriptions/event_detail.html
@@ -58,7 +58,8 @@ var event_object_id = '{{ object.id }}';
         <form class="subscribe" method="POST" action="">
             {% csrf_token %}
             {% if subscription.subscribed %}
-            <div class="message">Je bent al aangemeld.</div>
+            <div class="message"><strong>Je bent al aangemeld</strong>, maar je
+                kunt je nog afmelden.</div>
             {% elif subscription.invited and not subscription.has_mutations %}
             <div class="message">Je bent door
             <a href="{{ subscription.inviter.get_absolute_url }}"
@@ -66,18 +67,20 @@ var event_object_id = '{{ object.id }}';
             uitgenodigd.</div>
             {% endif %}
 
-            {% if not subscription.subscribed %}
             {% if object.can_subscribe %}
             <!--[if lte IE 9]>
             Opmerkingen:<br/>
             <![endif]-->
             <textarea class="default" name="notes" cols="30" rows="4"
                 placeholder="Opmerkingen"></textarea>
+            {% if not subscription.subscribed %}
             <input type="submit" name="subscribe" value="Aanmelden"/><br/>
+            {% else %}
+            <input type="submit" name="unsubscribe" value="Afmelden"/><br/>
+            {% endif %}{# subscription.subscribed #}
             {% else %}
             Je kunt je helaas niet meer aanmelden.
             {% endif %}{# object.can_subscribe #}
-            {% endif %}{# subscription.subscribed #}
         </form>
     </div>
 
@@ -115,12 +118,21 @@ var event_object_id = '{{ object.id }}';
     <button onclick="copy_emailaddresses_to_clipboard()">
         Toon e-mail adressen van de ingeschrevenen
     </button>
-    <h2>Aanmeldingen ({{ subscriptions|length }})</h2>
-    {% include "subscriptions/include_list.html" with list=subscriptions %}
+    {% if listSubscribed %}
+    <h2>Aanmeldingen ({{ listSubscribed|length }})</h2>
+    {% include "subscriptions/include_list.html" with list=listSubscribed %}
+    {% else %}
+    <p>Er zijn (nog) geen aanmeldingen.</p>
+    {% endif %}{# listSubscribed #}
 
-    {% if invitations %}
-    <h2>Uitnodigingen ({{ invitations|length }})</h2>
-    {% include "subscriptions/include_list.html" with list=invitations %}
-    {% endif %}
+    {% if listUnsubscribed %}
+    <h2>Afmeldingen ({{ listUnsubscribed|length }})</h2>
+    {% include "subscriptions/include_list.html" with list=listUnsubscribed %}
+    {% endif %}{# listUnsubscribed #}
+
+    {% if listInvited %}
+    <h2>Uitnodigingen ({{ listInvited|length }})</h2>
+    {% include "subscriptions/include_list.html" with list=listInvited %}
+    {% endif %}{# listInvited #}
 {% endif %}{# has_read_access or object.has_public_subscriptions#}
 {% endblock %}

--- a/kn/subscriptions/templates/subscriptions/include_list.html
+++ b/kn/subscriptions/templates/subscriptions/include_list.html
@@ -1,26 +1,26 @@
-	<ul>
-	{% for subscr in list %}
-	<li><a href="{{ subscr.user.get_absolute_url }}"
-		>{{ subscr.user.full_name }}</a>
-		{% if subscr.date %}
-			<small>{{ subscr.date.date }}</small>
-		{% endif %}{# subscr.date #}<br/>
+    <ul>
+    {% for subscr in list %}
+    <li><a href="{{ subscr.user.get_absolute_url }}"
+        >{{ subscr.user.full_name }}</a>
+        {% if subscr.date %}
+            <small>{{ subscr.date.date }}</small>
+        {% endif %}{# subscr.date #}<br/>
 
-		{% if has_read_access %}{# history #}
-		{% if subscr.userNotes %}
-		<blockquote>{{ subscr.userNotes }}</blockquote>
-		{% endif %}{# subscr.userNotes #}
+        {% if has_read_access %}{# history #}
+        {% if subscr.userNotes %}
+        <blockquote>{{ subscr.userNotes }}</blockquote>
+        {% endif %}{# subscr.userNotes #}
 
-		{% if subscr.invited %}
-		uitgenodigd door
-		<a href="{{ subscr.inviter.get_absolute_url }}"
-			>{{ subscr.inviter.full_name }}</a>
-		op {{ subscr.inviteDate.date }}
-		{% if subscr.inviterNotes %}
-		<blockquote>{{ subscr.inviterNotes }}</blockquote>
-		{% endif %}{# subscr.inviterNotes #}
-		{% endif %}{# subscr.invited #}
-		{% endif %}{# has_read_access #}
-		</li>
-	{% endfor %}
-	</ul>
+        {% if subscr.invited %}
+        uitgenodigd door
+        <a href="{{ subscr.inviter.get_absolute_url }}"
+            >{{ subscr.inviter.full_name }}</a>
+        op {{ subscr.inviteDate.date }}
+        {% if subscr.inviterNotes %}
+        <blockquote>{{ subscr.inviterNotes }}</blockquote>
+        {% endif %}{# subscr.inviterNotes #}
+        {% endif %}{# subscr.invited #}
+        {% endif %}{# has_read_access #}
+        </li>
+    {% endfor %}
+    </ul>

--- a/kn/subscriptions/templates/subscriptions/include_list.html
+++ b/kn/subscriptions/templates/subscriptions/include_list.html
@@ -2,16 +2,24 @@
     {% for subscr in list %}
     <li><a href="{{ subscr.user.get_absolute_url }}"
         >{{ subscr.user.full_name }}</a>
-        {% if subscr.date %}
-            <small>{{ subscr.date.date }}</small>
-        {% endif %}{# subscr.date #}<br/>
-
-        {% if has_read_access %}{# history #}
-        {% if subscr.userNotes %}
-        <blockquote>{{ subscr.userNotes }}</blockquote>
-        {% endif %}{# subscr.userNotes #}
-
+        {% if has_read_access %}
+        {% for mutation in subscr.history reversed %}
+        <div class="mutation">
+        {% if mutation.state == "subscribed" %}
+        aangemeld
+        {% elif mutation.state == "unsubscribed" %}
+        afgemeld
+        {% endif %}{# mutation.state #}
+        {% if mutation.date %}
+        op {{ mutation.date.date }}
+        {% endif %}{# mutation.date #}
+        {% if mutation.notes %}
+        <blockquote>{{ mutation.notes }}</blockquote>
+        {% endif %}{# mutation.notes #}
+        </div>
+        {% endfor %}{# subscr.history #}
         {% if subscr.invited %}
+        <div class="invitation">
         uitgenodigd door
         <a href="{{ subscr.inviter.get_absolute_url }}"
             >{{ subscr.inviter.full_name }}</a>
@@ -19,7 +27,12 @@
         {% if subscr.inviterNotes %}
         <blockquote>{{ subscr.inviterNotes }}</blockquote>
         {% endif %}{# subscr.inviterNotes #}
+        </div>
         {% endif %}{# subscr.invited #}
+        {% else %}
+        {% if subscr.date %}
+            <small>{{ subscr.date.date }}</small>
+        {% endif %}{# subscr.date #}
         {% endif %}{# has_read_access #}
         </li>
     {% endfor %}

--- a/kn/subscriptions/templates/subscriptions/include_list.html
+++ b/kn/subscriptions/templates/subscriptions/include_list.html
@@ -14,7 +14,7 @@
         op {{ mutation.date.date }}
         {% endif %}{# mutation.date #}
         {% if mutation.notes %}
-        <blockquote>{{ mutation.notes }}</blockquote>
+        <blockquote class="notes">{{ mutation.notes }}</blockquote>
         {% endif %}{# mutation.notes #}
         </div>
         {% endfor %}{# subscr.history #}
@@ -25,7 +25,7 @@
             >{{ subscr.inviter.full_name }}</a>
         op {{ subscr.inviteDate.date }}
         {% if subscr.inviterNotes %}
-        <blockquote>{{ subscr.inviterNotes }}</blockquote>
+        <blockquote class="notes">{{ subscr.inviterNotes }}</blockquote>
         {% endif %}{# subscr.inviterNotes #}
         </div>
         {% endif %}{# subscr.invited #}

--- a/kn/subscriptions/templates/subscriptions/subscription-notification.mail.html
+++ b/kn/subscriptions/templates/subscriptions/subscription-notification.mail.html
@@ -1,0 +1,46 @@
+{% block from %}
+Karpe Noktem Activiteiten <root@karpenoktem.nl>
+{% endblock from %}
+
+{% block subject %}
+Activiteit: {{ event.humanName }}
+{% endblock subject %}
+
+{% block html %}
+<p>Hallo {{ subscription.user.first_name }},</p>
+
+{% if mutation.state != "invited" %}
+<p>Je hebt je
+{% if mutation.state == "subscribed" %}aangemeld
+{% elif mutation.state == "unsubscribed" %}afgemeld
+{% endif %}
+voor <a href="{{ BASE_URL }}{{ event.get_absolute_url }}">{{ event.humanName }}</a>.</p>
+
+{% if mutation.notes %}
+<p>Je opmerkingen waren:
+<blockquote>{{ mutation.notes|linebreaksbr }}</blockquote>
+</p>
+{% else %}
+<p>Je had geen opmerkingen.</p>
+{% endif %}{# mutation.notes #}
+
+{% else %}
+
+<p>Je bent door {{ subscription.inviter.first_name }} uitgenodigd voor
+<a href="{{ BASE_URL }}{{ event.get_absolute_url }}">{{ event.humanName }}</a>.</p>
+
+{% if subscription.inviterNotes %}
+<p>{{ subscription.inviter.first_name }}'s opmerkingen waren:
+<blockquote>{{ subscription.inviterNotes|linebreaksbr }}</blockquote>
+</p>
+{% endif %}
+
+<p>Om deze uitnodiging te bevestigen, bezoek:<br/>
+&nbsp;&nbsp; <a href="{{ BASE_URL }}{{ event.get_absolute_url }}"
+                >{{ BASE_URL }}{{ event.get_absolute_url }}</a></p>
+{% endif %}{# mutation.state == "invited" #}
+
+<p>Met een vriendelijke groet,<br/>
+{{ event.owner.humanName }}
+</p>
+{% endblock html %}

--- a/kn/subscriptions/views.py
+++ b/kn/subscriptions/views.py
@@ -182,9 +182,6 @@ def event_new_or_edit(request, edit=None):
                 'description': fd['description'],
                 'description_html': kn.utils.markdown.parser.convert(
                                                 fd['description']),
-                'subscribedMailBody': fd['subscribedMailBody'],
-                'unsubscribedMailBody': fd['unsubscribedMailBody'],
-                'invitedMailBody': fd['invitedMailBody'],
                 'has_public_subscriptions': fd['has_public_subscriptions'],
                 'may_unsubscribe': fd['may_unsubscribe'],
                 'humanName': fd['humanName'],

--- a/kn/subscriptions/views.py
+++ b/kn/subscriptions/views.py
@@ -186,6 +186,7 @@ def event_new_or_edit(request, edit=None):
                 'unsubscribedMailBody': fd['unsubscribedMailBody'],
                 'invitedMailBody': fd['invitedMailBody'],
                 'has_public_subscriptions': fd['has_public_subscriptions'],
+                'may_unsubscribe': fd['may_unsubscribe'],
                 'humanName': fd['humanName'],
                 'createdBy': request.user._id,
                 'name': name,

--- a/kn/subscriptions/views.py
+++ b/kn/subscriptions/views.py
@@ -60,6 +60,16 @@ def event_detail(request, name):
             subscription = event.subscribe(request.user, notes)
         return HttpResponseRedirect(reverse('event-detail',
                                             args=(event.name,)))
+    elif request.method == 'POST' and 'unsubscribe' in request.POST:
+        if not event.can_unsubscribe:
+            raise PermissionDenied
+        if not subscription.subscribed:
+            messages.error(request, "Je bent al afgemeld")
+        else:
+            notes = request.POST['notes']
+            subscription = event.unsubscribe(request.user, notes)
+        return HttpResponseRedirect(reverse('event-detail',
+                                            args=(event.name,)))
     elif request.method == 'POST' and 'invite' in request.POST:
         if not event.is_open:
             raise PermissionDenied
@@ -80,17 +90,17 @@ def event_detail(request, name):
                              u != request.user,
                    Es.by_name('leden').get_members())
     users.sort(key=lambda u: unicode(u.humanName))
-    subscriptions = event.subscriptions
-    subscriptions.sort(key=lambda s: s.date)
-    invitations = event.invitations
-    invitations.sort(key=lambda i: i.date)
+    listSubscribed = sorted(event.listSubscribed, key=lambda s: s.date)
+    listUnsubscribed = sorted(event.listUnsubscribed, key=lambda s: s.date)
+    listInvited = sorted(event.listInvited, key=lambda s: s.date)
 
     ctx = {'object': event,
            'user': request.user,
            'users': users,
            'subscription': subscription,
-           'subscriptions': subscriptions,
-           'invitations': invitations,
+           'listSubscribed': listSubscribed,
+           'listUnsubscribed': listUnsubscribed,
+           'listInvited': listInvited,
            'has_read_access': has_read_access,
            'has_write_access': has_write_access}
     return render_to_response('subscriptions/event_detail.html', ctx,
@@ -173,6 +183,7 @@ def event_new_or_edit(request, edit=None):
                 'description_html': kn.utils.markdown.parser.convert(
                                                 fd['description']),
                 'subscribedMailBody': fd['subscribedMailBody'],
+                'unsubscribedMailBody': fd['unsubscribedMailBody'],
                 'invitedMailBody': fd['invitedMailBody'],
                 'has_public_subscriptions': fd['has_public_subscriptions'],
                 'humanName': fd['humanName'],

--- a/salt/states/sankhara/initial-db.yaml
+++ b/salt/states/sankhara/initial-db.yaml
@@ -766,5 +766,3 @@ events:
   description_html: <p>Beschrijving (in <strong>Markdown</strong>).</p>
   has_public_subscriptions: true
   subscriptions: []
-  subscribedMailBody: Hallo %(firstName)s,\r\n\r\nJe hebt je aangemeld voor %(eventName)s.\r\n\r\nJe opmerkingen waren:\r\n%(notes)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s
-  invitedMailBody: Hallo %(firstName)s,\r\n\r\nJe bent door %(by_firstName)s aangemeld voor %(eventName)s.\r\n\r\n%(by_firstName)s opmerkingen waren:\r\n%(by_notes)s\r\n\r\nOm deze aanmelding te bevestigen, bezoek:\r\n  %(confirmationLink)s\r\n\r\nMet een vriendelijke groet,\r\n\r\n%(owner)s


### PR DESCRIPTION
Functie zodat je je ook kunt afmelden zolang de activiteit nog open is.
Wat nog gedaan moet worden:
 * zorgen dat oude events ook de juiste mail templates hebben
 * een volledige geschiedenis van subscribe/unsubscribe acties weergeven
 * meer testen

Dit is vooral een eerste opzet voor review.
![screenshot-3](https://cloud.githubusercontent.com/assets/729697/12532447/d3e2d006-c214-11e5-84c7-af245ca55af4.png)

Een mogelijke extra feature zou een minimum aantal deelnemers kunnen zijn: als het aantal daaronder zit, kun je je niet (meer) afmelden. Voor activiteiten die dat nodig hebben.

Vooral bij die e-mail templates denk ik dat het anders moet.
De e-mail templates worden nauwelijks aangepast. Hoogstens een keer een kleine grappige aanpassing. Dus zo belangrijk is die mogelijkheid tot aanpassen niet.
Verder vind ik ze nogal beperkt. Het zijn tekstmails (geen HTML), het zijn geen Django templates waardoor ze minder flexibel zijn, en de 'templates' staan in Python code wat minder mooi is.

Mijn voorstel:
Herschrijf het huidige systeem volledig. Gebruik niet meer de oude Python string templates, maar maak mooie HTML templates. E-mails kunnen dan zowel in HTML als plain text verzonden worden, via eenzelfde systeem als voor de informacie gebruikt wordt (HTML naar Markdown converteren).
De voordelen van Django templates en HTML (die ik zo snel zie) zijn dat we bijvoorbeeld echte links kunnen gebruiken en wat logica, waarmee we dus niet per sé een leeg "opmerkingen:" stuk hebben. Verder zijn ze in elk geval een stuk makkelijker aan te passen (in code) als we in de toekomst dit soort updates hebben.

closes #151 