### PR TITLE
Add script that installs most to set up the machine with salt

### DIFF
--- a/kn/utils/giedo/quassel.py
+++ b/kn/utils/giedo/quassel.py
@@ -11,7 +11,7 @@ from django.conf import settings
 def generate_quassel_changes(giedo):
     db_path = os.path.join(settings.QUASSEL_CONFIGDIR, 'quassel-storage.sqlite')
     if not os.path.exists(db_path):
-        os.logging.warn('quassel: %s does not exist. Skipping.', db_path)
+        logging.warn('quassel: %s does not exist. Skipping.', db_path)
         return None
 
     # Check which users are currently on the core

--- a/salt/bootstrap-sankhara.sh
+++ b/salt/bootstrap-sankhara.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Before this script is run, make sure to configure the following:
+#  * A user 'infra' exists
+#  * The 'kninfra' repository is cloned into /vagrant, and owned by the user infra.
+#
+# You can do this with the following commands (as root):
+#    adduser infra
+#    git clone https://github.com/karpenoktem/kninfra.git /vagrant
+#    chown -R infra:infra /vagrant
+#
+# Then run this script.
+
+# Fail on errors.
+set -e
+
+# Make sure "sankhara" is in the hostname (needed for salt).
+if [[ "`hostname`" != *"sankhara"* ]]; then
+    echo "This host (`hostname`) doesn't have sankhara in it's name, abort."
+    exit 1
+fi
+
+# Make sure salt-minion is installed.
+if [ ! -e /usr/bin/salt-minion ]; then
+    apt update
+    apt install salt-minion
+fi
+
+# Set salt-minion to masterless mode.
+sed -i "s/#?file_client: .*$/file_client: local/" /etc/salt/minion
+# Don't run the minion daemon, we're going to use salt-call.
+systemctl stop salt-minion
+systemctl disable salt-minion
+# Some black magic to set the right file_roots:
+sed -i "s/^#file_roots:$/file_roots:/" /etc/salt/minion
+sed -i "/^file_roots:$/{n;s/.*/  base:/;n;s/.*/    - \/vagrant\/salt\/states/}" /etc/salt/minion
+# And again for pillar_roots:
+sed -i "s/^#pillar_roots:$/pillar_roots:/" /etc/salt/minion
+sed -i "/^pillar_roots:$/{n;s/.*/  base:/;n;s/.*/    - \/vagrant\/salt\/pillar/}" /etc/salt/minion
+
+# add the vagrant grain
+if ! egrep -q "^grains:$" /etc/salt/minion; then
+    # I've had enough of sed
+    cat << EOF >> /etc/salt/minion
+
+# Added by bootstrap script
+grains:
+  vagrant: true
+EOF
+fi
+
+if [ ! -e /vagrant/salt/pillar/vagrant.sls ]; then
+    python /vagrant/salt/states/sankhara/vagrant-sls.py > /vagrant/salt/pillar/vagrant.sls
+fi
+
+if [ ! -d /home/vagrant ]; then
+    adduser vagrant
+fi
+
+# ... aaaand run!
+salt-call --local state.highstate

--- a/salt/states/sankhara/vagrant-sls.py
+++ b/salt/states/sankhara/vagrant-sls.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+
+import random
+import string
+from copy import copy
+
+'''
+Creates initial data for the grain vagrant.sls
+'''
+
+STATIC = {
+    'ip-phassa':   '10.107.110.2',
+    'ip-sankhara': '10.107.110.3',
+    'ldap-suffix': 'dc=vagrant-sankhara,dc=lan',
+}
+SECRETS = ['chucknorris', 'django_secret_key', 'apikey', 'mysql_giedo',
+           'mysql_wiki', 'mysql_wolk', 'mysql_forum', 'mysql_root',
+           'mysql_daan', 'mailman_default', 'ldap_infra', 'ldap_daan',
+           'ldap_freeradius', 'ldap_admin', 'ldap_saslauthd', 'wiki_key',
+           'wiki_upgrade_key', 'wiki_admin', 'irc_services_secret',
+           'irc_die_pass', 'irc_restart_pass']
+
+def createVagrantGrains():
+    data = copy(STATIC)
+    data['secrets'] = {}
+    for name in SECRETS:
+        passwd = ''
+        for i in range(16):
+            passwd += random.choice(string.letters+string.digits)
+        data['secrets'][name] = passwd
+    return data
+
+
+
+if __name__ == '__main__':
+    data = createVagrantGrains()
+    import yaml
+    print yaml.dump(data, default_flow_style=False)


### PR DESCRIPTION
Het is niet mooi, maar voor mij doet het wat het moet doen.

Mogelijke verbeteringen:
 * Het zou mooier zijn om veel van deze configuratie naar salt te verplaatsen.
 * Misschien is het ook mooier om `/etc/salt/minion` in de repo te zetten zodat die simpelweg gekopieerd kan worden tijdens de bootstrap.
 * gebruik `vagrant-sls.py` ook vanuit Vagrant

Wat niet automatisch ging, was `www-data` toevoegen aan de groep `interinfra`. Dat heb ik maar handmatig gedaan, maar ik denk dat salt daar voor zou moeten zorgen.
Verder wordt niet heel salt opgezet. Er gaat bijvoorbeeld iets fout bij mailman (error) en in de MySQL verbinding van giedo (permission denied), maar het overgrote deel werkt. Ik heb het nu werkend op ratana.