### PR TITLE
Redirect naar karpenoktem.nl

### DIFF
--- a/salt/states/sankhara/site.nginx.conf
+++ b/salt/states/sankhara/site.nginx.conf
@@ -9,6 +9,10 @@ server {
     server_name {{ grains['fqdn'] }};
     {% endif %}
 
+    if ($host != "{{ grains['fqdn'] }}") {
+        return 301 https://{{ grains['fqdn'] }}$request_uri;
+    }
+
     {% if grains['vagrant'] %}
     # sendfile() does not always work on VirtualBox shared folders.
     # https://github.com/mitchellh/vagrant/issues/351#issuecomment-1339640


### PR DESCRIPTION
Dit werkt bij mij, maar salt weet nu niet of het domein op HTTPS zit.
Let wel op dat als je een (nginx) proxy gebruikt, de hostname intact blijft (dat was bij mij dus niet het geval).