### PR TITLE
Fix bug caused by property rename

### DIFF
--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -169,7 +169,7 @@ class Event(SONWrapper):
     @property
     def can_subscribe(self):
         if self.max_subscriptions is not None and \
-                len(self.subscriptions) >= self.max_subscriptions:
+                len(self.listSubscribed) >= self.max_subscriptions:
             return False
         return self.is_open
     @property

--- a/kn/subscriptions/views.py
+++ b/kn/subscriptions/views.py
@@ -138,7 +138,7 @@ def _api_get_email_addresses(request):
     return JsonHttpResponse({
             'success': True,
             'addresses': [s.user.canonical_full_email
-                    for s in event.subscriptions]})
+                    for s in event.listSubscribed]})
 
 @login_required
 def api(request):


### PR DESCRIPTION
'subscriptions' was renamed to 'listSubscriptions', but this rename wasn't applied everywhere.