### PR TITLE
Work around a browser bug in Safari in 'private browsing'

### DIFF
--- a/kn/base/media/common.js
+++ b/kn/base/media/common.js
@@ -3,6 +3,18 @@ var headerHeight = 400;
 var headerCollapsed = true;
 var expandHeader = true;
 
+// Work around a bug in Safari in private mode: Storage doesn't work.
+var supportsStorage = true;
+try {
+    localStorage.setItem('test', '');
+    localStorage.removeItem('test');
+    sessionStorage.setItem('test', '');
+    sessionStorage.removeItem('test');
+} catch (error) {
+    console.warn('localStorage or sessionStorage not supported');
+    supportsStorage = false;
+}
+
 function email(t, d, u) {
     var email = u + '@' + d + '.' + t;
     document.write('<a href="mailto:' + email + '">' + email + '</a>');
@@ -89,7 +101,7 @@ $(document).ready(function() {
         return false;
     });
 
-    if (expandHeader) {
+    if (expandHeader && supportsStorage) {
         /* reduce flicker on page load by loading the page with the header collapsed
          * and expanding it with JS while scrolling to the right position */
         $(document.body).addClass('header-expanded');
@@ -126,7 +138,9 @@ $(document).ready(function() {
         }
     }
 
-    sessionStorage['visited'] = 'true';
+    if (supportsStorage) {
+        sessionStorage['visited'] = 'true';
+    }
 
     $('.toggle').each(function(i, toggle) {
         toggle = $(toggle);


### PR DESCRIPTION
Dit zou het moeten fixen.
Ik heb een eerdere versie van de patch getest in Safari en daar was het een goede workaround. In andere browsers blijft het gewoon werken dus ik denk dat dit veilig online gezet kan worden om te testen of het nu ook in Safari werkt.

Het probleem is dat Safari in Private Browsing localStorage niet ondersteund, maar wel doet of het dat ondersteund. `Storage.setItem` geeft dan een error (quota exceeded), waardoor de rest van de code niet meer werkt.
Ik denk dat dit het probleem is met de aanmeldknop.