### PR TITLE
Handmatig username kiezen (2)

### DIFF
--- a/kn/leden/api.py
+++ b/kn/leden/api.py
@@ -8,6 +8,7 @@ from kn.base.mail import render_then_email
 import kn.leden.entities as Es
 from kn.leden.mongo import _id
 from kn.leden import giedo
+from kn.leden.utils import find_name_for_user
 
 @login_required
 def view(request):
@@ -196,6 +197,17 @@ def entity_set_property(data, request):
 
     return {'ok': True}
 
+def adduser_suggest_username(data, request):
+    if 'first_name' not in data or not isinstance(data['first_name'], basestring):
+        return {'ok': False, 'error': 'Missing argument "first_name"'}
+    if 'last_name' not in data or not isinstance(data['last_name'], basestring):
+        return {'ok': False, 'error': 'Missing argument "last_name"'}
+
+    if not 'secretariaat' in request.user.cached_groups_names:
+        return {'ok': False, 'error': 'Permission denied'}
+
+    return {'ok': True,
+            'username': find_name_for_user(data['first_name'], data['last_name'])}
 
 ACTION_HANDLER_MAP = {
         'entity_humanName_by_id': entity_humanName_by_id,
@@ -205,6 +217,7 @@ ACTION_HANDLER_MAP = {
         'entity_update_primary':  entity_update_primary,
         'entity_update_visibility':  entity_update_visibility,
         'get_last_synced':  get_last_synced,
+        'adduser_suggest_username': adduser_suggest_username,
         None: no_such_action,
         }
 

--- a/kn/leden/forms.py
+++ b/kn/leden/forms.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import reserved
 
 from django.utils.safestring import mark_safe
 from django.core.urlresolvers import reverse
@@ -54,6 +55,8 @@ def validate_username(username):
         raise forms.ValidationError('Gebruikersnaam is al in gebruik')
     if any(map(lambda c: c not in settings.USERNAME_CHARS, username)):
         raise forms.ValidationError('Gebruikersnaam heeft niet-toegestaan karakter')
+    if not reserved.allowed(username):
+        raise forms.ValidationError('Gebruikersnaam is niet toegestaan')
 
 class AddUserForm(forms.Form):
     last_name = forms.CharField(label="Achternaam",
@@ -85,6 +88,7 @@ class AddUserForm(forms.Form):
             choices=[('eerstejaars', 'Eerstejaars'), ('aan', "Aan"),
                      ('uit', "Uit"), ('zooi', 'Zooi')],
             initial=['leden', 'eerstejaars', 'aan'],
+            required=False,
             widget=forms.CheckboxSelectMultiple())
 
 class AddGroupForm(forms.Form):

--- a/kn/leden/forms.py
+++ b/kn/leden/forms.py
@@ -6,6 +6,7 @@ from django.core.urlresolvers import reverse
 from django.forms.widgets import flatatt
 from django.utils.html import escape
 from django import forms
+from django.conf import settings
 
 import kn.leden.entities as Es
 
@@ -48,11 +49,19 @@ class EntityChoiceField(forms.CharField):
         kwargs['widget'] = EntityChoiceFieldWidget(_type=_type)
         super(EntityChoiceField, self).__init__(*args, **kwargs)
 
+def validate_username(username):
+    if username in Es.names():
+        raise forms.ValidationError('Gebruikersnaam is al in gebruik')
+    if any(map(lambda c: c not in settings.USERNAME_CHARS, username)):
+        raise forms.ValidationError('Gebruikersnaam heeft niet-toegestaan karakter')
+
 class AddUserForm(forms.Form):
     last_name = forms.CharField(label="Achternaam",
                     widget=forms.TextInput(attrs={
                         'placeholder': 'bijv.: Vaart, van der'}))
     first_name = forms.CharField(label="Voornaam")
+    username = forms.CharField(label="Gebruikersnaam",
+                    validators=[validate_username])
     gender = forms.ChoiceField(label="Geslacht", choices=(('m', 'Man'),
                                ('v', 'Vrouw')))
     email = forms.EmailField(label="E-Mail adres")

--- a/kn/leden/templates/leden/secr_add_user.html
+++ b/kn/leden/templates/leden/secr_add_user.html
@@ -1,6 +1,60 @@
 {% extends "leden/base.html" %}
 {% load base %}
 
+{% block head %}
+{{ block.super }}
+<script>
+'use strict';
+
+var previous_username = null;
+var username_timeout = null;
+
+// Implement automatically suggesting a username:
+//   * with a delay of 300ms
+//   * without running two requests in parallel
+//   * only when the username field hasn't been modified
+function update_username() {
+    if (username_timeout === -1) {
+        // a request is pending
+        return;
+    }
+    var username_input = $('#id_username');
+    if (previous_username !== null &&
+            previous_username !== username_input.val() &&
+            username_input.val()) {
+        return;
+    }
+
+    clearTimeout(username_timeout);
+    setTimeout(function() {
+        var last_name = $('#id_last_name').val();
+        var first_name = $('#id_first_name').val();
+        username_timeout = -1;
+        leden_api({
+                action: 'adduser_suggest_username',
+                last_name: last_name,
+                first_name: first_name},
+            function(data) {
+                username_timeout = null;
+                if (!data.ok) {
+                    alert(data.error);
+                } else {
+                    username_input.val(data.username);
+                    previous_username = data.username;
+                }
+            });
+    }, 300);
+}
+
+$(function() {
+    previous_username = $('#id_username').val();
+    console.log('previous', previous_username);
+    $('#id_last_name').on('input', update_username);
+    $('#id_first_name').on('input', update_username);
+})
+</script>
+{% endblock head %}
+
 {% block body %}
 <form method="post" action="?">{% csrf_token %}
 <table>

--- a/kn/leden/views.py
+++ b/kn/leden/views.py
@@ -524,7 +524,7 @@ def secr_add_user(request):
                 'is_active': True,
                 'password': None
                 })
-            logging.info("Added user %s" % nm)
+            logging.info("Added user %s" % fd['username'])
             u.save()
             # Then, add the relations.
             groups = ['leden']
@@ -557,7 +557,7 @@ def secr_add_user(request):
                             'u': u})
             Es.notify_informacie('adduser', request.user, entity=u._id)
             return HttpResponseRedirect(reverse('user-by-name',
-                    args=(nm,)))
+                    args=(fd['username'],)))
     else:
         form = AddUserForm()
     return render_to_response('leden/secr_add_user.html',

--- a/kn/leden/views.py
+++ b/kn/leden/views.py
@@ -24,7 +24,6 @@ from django.contrib import messages
 
 from kn.leden.forms import ChangePasswordForm, AddUserForm, AddGroupForm
 from kn.leden.auth import login_or_basicauth_required
-from kn.leden.utils import find_name_for_user
 from kn.leden.date import now, date_to_dt
 from kn.leden.mongo import _id
 from kn.leden import giedo
@@ -486,12 +485,10 @@ def secr_add_user(request):
         form = AddUserForm(request.POST)
         if form.is_valid():
             fd = form.cleaned_data
-            nm = find_name_for_user(fd['first_name'],
-                        fd['last_name'])
             # First, create the entity.
             u = Es.User({
                 'types': ['user'],
-                'names': [nm],
+                'names': [fd['username']],
                 'humanNames': [{'human': fd['first_name']+' '+
                              fd['last_name']}],
                 'person': {

--- a/salt/states/sankhara/kninfra.sls
+++ b/salt/states/sankhara/kninfra.sls
@@ -25,6 +25,8 @@ sarah:
     pip.installed
 tarjan:
     pip.installed
+reserved:
+    pip.installed
 infra:
     group.present:
         - gid: 2000


### PR DESCRIPTION
Hier een nieuwe poging voor #365. Hiermee wordt via een API-call een gebruikersnaam gemaakt uit een voor en achternaam. Op de server wordt daarna nog gecheckt of de ingevoerde gebruikersnaam aan de eisen voldoet (geen speciale tekens en geen speciale gebruikersnamen zoals `admin` of `postfix`). Enige wat niet geïmplementeerd is, is checken of een gebruikersnaam wel mag in `find_name_for_user`, maar dat leek me niet heel hard nodig.

Ik heb getest dat een gebruiker nog steeds toegevoegd kan worden, en dat special usernames niet toegestaan zijn.