### PR TITLE
Beter authenticatie voor de planning

### DIFF
--- a/kn/defaultSettings.py
+++ b/kn/defaultSettings.py
@@ -162,6 +162,7 @@ def defaultSettings(glbls):
             "django.core.context_processors.media",
             "django.contrib.messages.context_processors.messages",
             "kn.base.context_processors.base_url",
+            "kn.leden.context_processors.may_manage_planning",
     )
     d.TEMPLATE_DIRS = ()
     d.AUTHENTICATION_BACKENDS = (

--- a/kn/leden/context_processors.py
+++ b/kn/leden/context_processors.py
@@ -1,0 +1,7 @@
+
+import kn.planning.entities as pEs
+
+def may_manage_planning(request):
+    return {'may_manage_planning': pEs.may_manage_planning(request.user)}
+
+# vim: et:sta:bs=2:sw=4:

--- a/kn/leden/templates/leden/base.html
+++ b/kn/leden/templates/leden/base.html
@@ -57,7 +57,7 @@
         {% endif %}
 
         <li><a href="{% url "planning-home"  %}">Planning</a>
-            {% if "bestuur" in user.cached_groups_names or "barco" in user.cached_groups_names or "disco" in user.cached_groups_names or "chef" in user.cached_groups_names or "secretariaat" in user.cached_groups_names %}
+            {% if may_manage_planning %}
             <ul>
                 <li><a href="{% url "planning-poollist" %}">Beheer</a></li>
                 <li><a href="{% url "planning-event-create" %}">Nieuw</a></li>

--- a/kn/planning/entities.py
+++ b/kn/planning/entities.py
@@ -117,6 +117,13 @@ class Pool(SONWrapper):
             self._group = Es.by_name(self.name)
         return self._group
 
+    def may_manage(self, user):
+        '''
+        Is this user allowed to manage this pool?
+        '''
+        return bool(user.cached_groups_names & set(['secretariaat',
+            self.administrator]))
+
 # Generic functions for Vacancy.begin and end.
 #
 # These fields are either a datetime d or a tuple (d,a),

--- a/kn/planning/entities.py
+++ b/kn/planning/entities.py
@@ -10,6 +10,16 @@ pcol = db['planning_pools']
 ecol = db['planning_events']
 vcol = db['planning_vacancies']
 
+PLANNER_GROUPS = {'bestuur', 'barco', 'disco', 'chef', 'secretariaat'}
+
+def may_manage_planning(user):
+    if user is None:
+        return False
+    if not hasattr(user, 'cached_groups_names'):
+        # e.g. AnonymousUser
+        return False
+    return bool(user.cached_groups_names & PLANNER_GROUPS)
+
 # TODO save vacancies in events?
 
 # ---

--- a/kn/planning/templates/planning/overview.html
+++ b/kn/planning/templates/planning/overview.html
@@ -33,9 +33,14 @@
             <td
                 colspan="{{ pools|length }}"
                 class="poolHeader">
+                {% if may_manage_planning %}
                 <a href="{% url "planning-event-edit" eventid=event.id %}">
                     <strong>{{ event.datetime|date:"l j F Y" }}</strong>
                     - {{ event.name }}</a>
+                {% else %}
+                    <strong>{{ event.datetime|date:"l j F Y" }}</strong>
+                    - {{ event.name }}
+                {% endif %}
             </td>
         </tr>
         <tr>

--- a/kn/planning/views.py
+++ b/kn/planning/views.py
@@ -12,7 +12,7 @@ from kn.leden.date import date_to_dt, now, date_to_midnight
 from kn.leden.mongo import _id
 
 from kn.planning.forms import *
-from kn.planning.entities import Pool, Event, Vacancy
+from kn.planning.entities import Pool, Event, Vacancy, may_manage_planning
 from kn.planning.score import planning_vacancy_worker_score
 from kn.planning.utils import send_reminder
 
@@ -220,6 +220,8 @@ def planning_poollist(request):
 
 @login_required
 def event_create(request):
+    if not may_manage_planning(request.user):
+        raise PermissionDenied
     if request.method == 'POST':
         form = EventCreateForm(request.POST)
         if form.is_valid():
@@ -254,6 +256,8 @@ def event_create(request):
 
 @login_required
 def event_edit(request, eventid):
+    if not may_manage_planning(request.user):
+        raise PermissionDenied
     avform = None
     e = Event.by_id(eventid)
     if request.method == 'POST':


### PR DESCRIPTION
Lokaal getest:
* als admin (secretariaat): mag alles
* als gewone gebruiker: mag alleen inzien
* als gebruiker in 'bestuur': mag alleen planningen aanmaken/wijzigen en vacancies voor bestuur invullen.

De tweede commit doet een paar extra aanpassingen die niet kritiek zijn, maar die ik zo wel mooier vind.