### PR TITLE
Verberg groepsleden

### DIFF
--- a/kn/leden/entities.py
+++ b/kn/leden/entities.py
@@ -747,6 +747,21 @@ class Entity(SONWrapper):
                     str(n) for n in g.names])
         return self._groups_names_cache
 
+    @property
+    def cached_tags(self):
+        if not hasattr(self, '_tags_cache'):
+            self._tags_cache = set(self.get_tags())
+        return self._tags_cache
+
+    @property
+    def cached_tags_names(self):
+        if not hasattr(self, '_tags_names_cache'):
+            self._tags_names_cache = set()
+            for t in self.cached_tags:
+                self._tags_names_cache.update([
+                    str(n) for n in t.names])
+        return self._tags_names_cache
+
     # get reverse-related
     def get_rrelated(self, how=-1, _from=None, until=None, deref_who=True,
                 deref_with=True, deref_how=True):

--- a/kn/leden/templates/leden/entity_base.html
+++ b/kn/leden/templates/leden/entity_base.html
@@ -134,6 +134,10 @@ $(function(){
 {% endif %}{# may_add_related #}
 
 {% if rrelated %}
+{% if "!hide-members" in object.cached_tags_names and not "secretariaat" in user.cached_groups_names %}
+<h3>{% trans "Leden" %}</h3>
+<em>Leden zijn verborgen.</em>
+{% else %}
 <h3>{% trans "Leden" %} ({{ year_counts.this }})</h3>
 <ul>
 {% for r in rrelated %}
@@ -166,7 +170,9 @@ $(function(){
 {% endfor %}
 </li>
 </ul>
-{% endif %}
+{% endif %}{# "!hide-members" in object.cached_tags_names and not "secretariaat" in user.cached_groups_names #}
+{% endif %}{# rrelated #}
+
 {% if may_add_rrelated %}
 {% if rrelated or object.is_group %}
 <form action="{% url "relation-begin" %}" method="post"

--- a/salt/states/sankhara/initial-db.yaml
+++ b/salt/states/sankhara/initial-db.yaml
@@ -396,43 +396,70 @@ entities:
   names: [loco]
   tags: [!id '4e6fcc85e60edf3dc000007d']
   types: [group, tag]
+- _id: &lists_id !id '4e6fcc85e60edf3dc00000b9'
+  description: De E-Mail Lijsten.
+  humanNames:
+  - {genitive_prefix: van de, human: E-Mail Lijsten, name: lists}
+  names: [lists]
+  tags: [*root_id]
+  types: [tag]
+- _id: &lists_auto_id !id '4e6fcc85e60edf3dc00000bb'
+  description: E-Maillijsten waarvan lidmaatschap automatisch wordt bepaald.
+  humanNames:
+  - {genitive_prefix: van de, human: Automatische E-Maillijsten, name: lists-auto}
+  names: [lists-auto]
+  tags: [*lists_id]
+  types: [tag]
+- _id: &lists_other_id !id 4e6fcc85e60edf3dc00000bc
+  description: De e-maillijsten waar je zelf lid van kunt worden.
+  humanNames:
+  - {genitive_prefix: van de, human: Vrijwillige E-Maillijsten, name: lists-opted}
+  names: [lists-opted]
+  tags: [*lists_id]
+  types: [tag]
+- description: Andere e-maillijsten of doorverwijzingen
+  humanNames:
+  - {genitive_prefix: van de, human: Andere E-Maillijsten, name: lists-other}
+  names: [lists-other]
+  tags: [*lists_id]
+  types: [tag]
 - description: De hoofden van de commissies van Karpe Noktem.
   humanNames:
   - {genitive_prefix: van de, human: Hoofden, name: hoofden}
   names: [hoofden]
-  tags: [!id '4e6fcc85e60edf3dc00000bb']
+  tags: [*lists_auto_id]
   types: [group, tag]
 - description: De mannelijke leden van Karpe Noktem.
   humanNames:
   - {genitive_prefix: van de, human: Mannen, name: mannen}
   names: [mannen]
-  tags: [!id '4e6fcc85e60edf3dc00000bb']
+  tags: [*lists_auto_id]
   types: [group, tag]
 - description: De vrouwelijke leden van Karpe Noktem.
   humanNames:
   - {genitive_prefix: van de, human: Vrouwen, name: vrouwen}
   names: [vrouwen]
-  tags: [!id '4e6fcc85e60edf3dc00000bb']
+  tags: [*lists_auto_id]
   types: [group, tag]
 - _id: !id '4e6fcc85e60edf3dc00000a4'
   description: Leden die een incassoformulier hebben getekend.
   humanNames:
   - {genitive_prefix: van de, human: Incasso, name: incasso}
   names: [incasso]
-  tags: [!id '4e6fcc85e60edf3dc00000bb']
+  tags: [*groepen_id]
   types: [group, tag]
 - _id: !id '4e6fcc85e60edf3dc00000a5'
   description: Leden die geen incassoformulier hebben getekend.
   humanNames:
   - {genitive_prefix: van de, human: Geen Incasso, name: geen-incasso}
   names: [geen-incasso]
-  tags: [!id '4e6fcc85e60edf3dc00000bb']
+  tags: [*groepen_id]
   types: [group, tag]
 - description: Frequent impulsief uitgaande mensen
   humanNames:
   - {genitive_prefix: van de, human: Uit, name: uit}
   names: [uit, sex, bier, parijs]
-  tags: [!id '4e6fcc85e60edf3dc00000bc', !id '4ea9ce060032a04a41000001']
+  tags: [*lists_other_id, !id '4ea9ce060032a04a41000001']
   types: [group, tag]
 - _id: !id '4e6fcc85e60edf3dc000007d'
   description: Alle commissies van Karpe Noktem.
@@ -457,7 +484,7 @@ entities:
   humanNames:
   - {genitive_prefix: van de, human: EersteJaars, name: eerstejaars}
   names: [eerstejaars]
-  tags: [!id '4e6fcc85e60edf3dc00000bb']
+  tags: [*lists_auto_id]
   types: [group, tag]
 - description: De Fotografen.
   humanNames:
@@ -493,39 +520,19 @@ entities:
   humanNames:
   - {genitive_prefix: van de, human: Discussie, name: discussie}
   names: [discussie]
-  tags: [!id '4e6fcc85e60edf3dc00000bc', !id '4ea9ce060032a04a41000001']
+  tags: [*lists_other_id, !id '4ea9ce060032a04a41000001']
   types: [group, tag]
-- description: De E-Mail Lijsten.
-  humanNames:
-  - {genitive_prefix: van de, human: E-Mail Lijsten, name: lists}
-  names: [lists]
-  tags: [*root_id]
-  types: [tag]
 - description: "De e-maillijst met de ge\xEFnteresseerde oud leden."
   humanNames:
   - {genitive_prefix: van de, human: Oud, name: oud}
   names: [oud]
-  tags: [!id '4e6fcc85e60edf3dc00000bc']
+  tags: [*lists_other_id]
   types: [group, tag]
-- _id: !id '4e6fcc85e60edf3dc0000094'
-  description: E-Maillijsten waarvan lidmaatschap automatisch wordt bepaald.
-  humanNames:
-  - {genitive_prefix: van de, human: Automatische E-Maillijsten, name: lists-auto}
-  names: [lists-auto]
-  tags: [!id '4e6fcc85e60edf3dc00000b9']
-  types: [tag]
-- _id: !id 4e6fcc85e60edf3dc00000bc
-  description: De e-maillijsten waar je zelf lid van kunt worden.
-  humanNames:
-  - {genitive_prefix: van de, human: Vrijwillige E-Maillijsten, name: lists-opted}
-  names: [lists-opted]
-  tags: [!id '4e6fcc85e60edf3dc00000b9']
-  types: [tag]
 - description: "De re\xFCnisten van onze vereniging."
   humanNames:
   - {genitive_prefix: van de, human: "Re\xFCnisten", name: reunisten}
   names: [reunisten]
-  tags: [!id '4e6fcc85e60edf3dc00000bb']
+  tags: [*lists_auto_id]
   types: [group, tag]
 - description: De tappers van de Barco.
   humanNames:
@@ -537,14 +544,8 @@ entities:
   humanNames:
   - {genitive_prefix: van de, human: Ereleden, name: ereleden}
   names: [ereleden]
-  tags: [!id '4e6fcc85e60edf3dc00000bb']
+  tags: [*lists_auto_id]
   types: [group, tag]
-- description: Andere e-maillijsten of doorverwijzingen
-  humanNames:
-  - {genitive_prefix: van de, human: Andere E-Maillijsten, name: lists-other}
-  names: [lists-other]
-  tags: [!id '4e6fcc85e60edf3dc00000b9']
-  types: [tag]
 - humanNames:
   - {human: Wel jaar 10}
   tags: [!id '4e6fcc85e60edf3dc0000001']
@@ -616,7 +617,7 @@ entities:
   humanNames:
   - {genitive_prefix: van de, human: InformaCie, name: informacie}
   names: [informacie]
-  tags: [!id '4ea9ce060032a04a41000001', !id '4e6fcc85e60edf3dc00000bc']
+  tags: [!id '4ea9ce060032a04a41000001', *lists_other_id]
   types: [group, tag]
 - description: De Pluk de Nacht Weekend organiserende groep
   humanNames:
@@ -660,7 +661,7 @@ entities:
   humanNames:
   - {genitive_prefix: van de, human: Leden, name: leden}
   names: [leden]
-  tags: [!id '4e6fcc85e60edf3dc00000bb', !id '4e6fcc85e60edf3dc0000004']
+  tags: [*lists_auto_id, !id '4e6fcc85e60edf3dc0000004']
   types: [group, tag]
 - description: De WebCie regelt de digitale voorzieningen voor Karpe Noktem
   humanNames:

--- a/salt/states/sankhara/initial-db.yaml
+++ b/salt/states/sankhara/initial-db.yaml
@@ -35,6 +35,12 @@ entities:
   names: ['!can-organize-official-events']
   tags: [*system_id]
   types: [tag]
+- _id: &hide_members_id !id '58600675fc8e9ecec4fae142'
+  humanNames:
+  - {human: Verberg leden, name: '!hide-members'}
+  names: ['!hide-members']
+  tags: [*system_id]
+  types: [tag]
 - _id: !id '4e6fcc85e60edf3dc0000005'
   humanNames:
   - {human: Wel jaar 1}
@@ -446,14 +452,14 @@ entities:
   humanNames:
   - {genitive_prefix: van de, human: Incasso, name: incasso}
   names: [incasso]
-  tags: [*groepen_id]
+  tags: [*groepen_id, *hide_members_id]
   types: [group, tag]
 - _id: !id '4e6fcc85e60edf3dc00000a5'
   description: Leden die geen incassoformulier hebben getekend.
   humanNames:
   - {genitive_prefix: van de, human: Geen Incasso, name: geen-incasso}
   names: [geen-incasso]
-  tags: [*groepen_id]
+  tags: [*groepen_id, *hide_members_id]
   types: [group, tag]
 - description: Frequent impulsief uitgaande mensen
   humanNames:

--- a/salt/states/sankhara/initial-db.yaml
+++ b/salt/states/sankhara/initial-db.yaml
@@ -1,5 +1,5 @@
 entities:
-- _id: !id '4e6fcc85e60edf3dc0000000'
+- _id: &system_id !id '4e6fcc85e60edf3dc0000000'
   humanNames:
   - {human: Systeemstempels, name: '!system'}
   names: ['!system']
@@ -9,31 +9,31 @@ entities:
   humanNames:
   - {human: Jaarlidmaatschapstempels, name: '!year-overrides'}
   names: ['!year-overrides']
-  tags: [!id '4e6fcc85e60edf3dc0000000']
+  tags: [*system_id]
   types: [tag]
 - _id: !id '4e6fcc85e60edf3dc0000002'
   humanNames:
   - {human: Virtuele groep, name: '!virtual-group'}
   names: ['!virtual-group']
-  tags: [!id '4e6fcc85e60edf3dc0000000']
+  tags: [*system_id]
   types: [tag]
 - _id: !id '4e6fcc85e60edf3dc0000003'
   humanNames:
   - {human: Sofa merk, name: '!sofa-brand'}
   names: ['!sofa-brand']
-  tags: [!id '4e6fcc85e60edf3dc0000000']
+  tags: [*system_id]
   types: [tag]
 - _id: !id '4e6fcc85e60edf3dc0000004'
   humanNames:
   - {human: Jaargroep, name: '!year-group'}
   names: ['!year-group']
-  tags: [!id '4e6fcc85e60edf3dc0000000']
+  tags: [*system_id]
   types: [tag]
 - _id: !id 56af677edef5152cf39aa2bc
   humanNames:
   - {human: Mag officiële activiteiten organiseren, name: '!can-organize-official-events'}
   names: ['!can-organize-official-events']
-  tags: [!id '4e6fcc85e60edf3dc0000000']
+  tags: [*system_id]
   types: [tag]
 - _id: !id '4e6fcc85e60edf3dc0000005'
   humanNames:
@@ -605,7 +605,7 @@ entities:
   humanNames:
   - {human: Vrijelijk betreedbaar, name: '!free-to-join'}
   names: ['!free-to-join']
-  tags: [!id '4e6fcc85e60edf3dc0000000']
+  tags: [*system_id]
   types: [tag]
 - description: De drankboekhouding lezende groep
   humanNames:

--- a/salt/states/sankhara/initial-db.yaml
+++ b/salt/states/sankhara/initial-db.yaml
@@ -355,11 +355,19 @@ entities:
   names: [bestuur, bestuul, parkhangen, festivals]
   tags: [!id '4e6fcc85e60edf3dc0000004']
   types: [group, tag]
-- _id: !id '4e6fcc85e60edf3dc000007e'
+- _id: &root_id !id '4e6fcc85e60edf3dc0000086'
+  description: Categorieen van onderverdelingen der leden.
+  humanNames:
+  - {genitive_prefix: van de, human: Onderverdelingen, name: root}
+  names: [root, sms-gateway]
+  tags: [*root_id]
+  types: [tag]
+- _id: &groepen_id !id '4e6fcc85e60edf3dc000007e'
   description: Alle overige mailinglists.
   humanNames:
   - {genitive_prefix: van de, human: Groepen, name: groepen}
   names: [groepen]
+  tags: [*root_id]
   types: [tag]
 - description: De kascontrolecommissie
   humanNames:
@@ -372,14 +380,14 @@ entities:
   humanNames:
   - {genitive_prefix: van de, human: FotoCie, name: fotocie}
   names: [fotocie, fotos]
-  tags: [!id '4e6fcc85e60edf3dc000007e']
+  tags: [*groepen_id]
   types: [group, tag]
 - _id: !id 50bcaaec0032a07ed8000000
   description: Organisatie van het kerstgala
   humanNames:
   - {genitive_prefix: van de, human: Galagroep, name: galagroep}
   names: [galagroep]
-  tags: [!id '4e6fcc85e60edf3dc000007e', !id 56af677edef5152cf39aa2bc]
+  tags: [*groepen_id, !id 56af677edef5152cf39aa2bc]
   types: [group, tag]
 - _id: !id '4e6fcc85e60edf3dc000006f'
   description: De loze activiteitencommissie.
@@ -431,27 +439,13 @@ entities:
   humanNames:
   - {genitive_prefix: van de, human: Commissies, name: comms}
   names: [comms]
-  tags: [!id '4e6fcc85e60edf3dc0000086']
-  types: [tag]
-- _id: !id '4e6fcc85e60edf3dc000007e'
-  description: Alle overige mailinglists.
-  humanNames:
-  - {genitive_prefix: van de, human: Groepen, name: groepen}
-  names: [groepen]
-  tags: [!id '4e6fcc85e60edf3dc0000086']
-  types: [tag]
-- _id: !id '4e6fcc85e60edf3dc0000086'
-  description: Categorieen van onderverdelingen der leden.
-  humanNames:
-  - {genitive_prefix: van de, human: Onderverdelingen, name: root}
-  names: [root, sms-gateway]
-  tags: [!id '4e6fcc85e60edf3dc0000086']
+  tags: [*root_id]
   types: [tag]
 - description: Besturen der ASV Karpe Noktem.
   humanNames:
   - {genitive_prefix: van de, human: Besturen, name: besturen}
   names: [besturen]
-  tags: [!id '4e6fcc85e60edf3dc0000086']
+  tags: [*root_id]
   types: [tag]
 - description: De wortel van de WebCie.
   humanNames:
@@ -481,7 +475,7 @@ entities:
   humanNames:
   - {genitive_prefix: van de, human: Moderators, name: moderators}
   names: [moderators, veiligheid, mods, censuur, forum-abuse, spellingscontrole]
-  tags: [!id '4e6fcc85e60edf3dc000007e']
+  tags: [*groepen_id]
   types: [group, tag]
 - description: De platen draaiende groep.
   humanNames:
@@ -505,7 +499,7 @@ entities:
   humanNames:
   - {genitive_prefix: van de, human: E-Mail Lijsten, name: lists}
   names: [lists]
-  tags: [!id '4e6fcc85e60edf3dc0000086']
+  tags: [*root_id]
   types: [tag]
 - description: "De e-maillijst met de ge\xEFnteresseerde oud leden."
   humanNames:
@@ -589,20 +583,20 @@ entities:
   humanNames:
   - {genitive_prefix: van de, human: Boekenlezers, name: boekenlezers}
   names: [boekenlezers]
-  tags: [!id '4e6fcc85e60edf3dc000007e']
+  tags: [*groepen_id]
   types: [group, tag]
 - description: Secretariaat
   _id: &secretariaat_id !id 'aaaaaaaaaaaaaaaaaaa00002'
   humanNames:
   - {genitive_prefix: van het, human: Secretariaat, name: secretariaat}
   names: [secretariaat]
-  tags: [!id '4e6fcc85e60edf3dc000007e']
+  tags: [*groepen_id]
   types: [group, tag]
 - description: De lezers van de ledenadministratie
   humanNames:
   - {genitive_prefix: van de, human: Administratielezers, name: admlezers}
   names: [admlezers]
-  tags: [!id '4e6fcc85e60edf3dc000007e']
+  tags: [*groepen_id]
   types: [group, tag]
 - _id: !id 4ea9ce060032a04a41000001
   description: Alle groepen die met "Vrijelijk betreedbaar" zijn getagged kun je zelf
@@ -616,7 +610,7 @@ entities:
   humanNames:
   - {genitive_prefix: van de, human: Dranklezers, name: dranklezers}
   names: [dranklezers]
-  tags: [!id '4e6fcc85e60edf3dc000007e']
+  tags: [*groepen_id]
   types: [group, tag]
 - description: De InformaCie wordt op de hoogte gesteld van wijzigingen aan de ledenadministratie
   humanNames:
@@ -719,7 +713,7 @@ entities:
   humanNames:
   - {genitive_prefix: van de, human: Disputen, name: disputen}
   names: [disputen]
-  tags: [!id '4e6fcc85e60edf3dc0000086']
+  tags: [*root_id]
   types: [tag]
 
 - _id: &test_id !id '4e6fcc85e60edf3dc00001d4'


### PR DESCRIPTION
Voor `incasso`, `geen-incasso`, en in de toekomst de leden die nog geen toestemming hebben gegeven voor het doorgeven van naam+studentnummer

Helaas is dit niet compleet, leden kunnen (ten minste) nog steeds op de volgende manieren worden gevonden:

* mailman lijst lidmaatschappen
* phassa groepen

Vandaar dat deze pull request nog niet compleet is (WIP), maar ik maak alvast een pull request voor review.