### PR TITLE
Add 'Aan' mailing list to initial DB

### DIFF
--- a/salt/states/sankhara/initial-db.yaml
+++ b/salt/states/sankhara/initial-db.yaml
@@ -420,6 +420,12 @@ entities:
   names: [geen-incasso]
   tags: [!id '4e6fcc85e60edf3dc00000bb']
   types: [group, tag]
+- description: De opt-out mailinglist.
+  humanNames:
+  - {genitive_prefix: van de, human: Aan, name: aan}
+  names: [aan]
+  tags: [!id '4e6fcc85e60edf3dc00000bc', !id '4ea9ce060032a04a41000001']
+  types: [group, tag]
 - description: Frequent impulsief uitgaande mensen
   humanNames:
   - {genitive_prefix: van de, human: Uit, name: uit}


### PR DESCRIPTION
De 'aan' is ook standaard aangevinkt bij het aanmaken van een account, dus het is makkelijk als die ook in de initial DB staat (om fouten te voorkomen).