### PR TITLE
Don't set the language simply by going to an URL

### DIFF
--- a/kn/base/backports.py
+++ b/kn/base/backports.py
@@ -22,7 +22,6 @@ from django.conf import settings
 #  1. The Accept-Language header is ignored if it suggests English.
 #  2. URLs like /nl/... still work even though prefix_default_language
 #     is set to False.
-#  3. A preferred language is stored in the user-object
 # #############################################################################
 
 
@@ -105,16 +104,6 @@ class BackportedLocaleMiddleware(object):
                     1
                 )
                 return self.response_redirect_class(language_url)
-
-        # NOTE In Django 1.10 this is taken care of in other middleware
-        #      and that is why this session update is not in the 1.10
-        #      locale middleware.
-        if hasattr(request, 'session') and language_from_path:
-            request.session['_language'] = language
-            # NOTE customization 3:
-            if (hasattr(request, 'user') and request.user.is_authenticated()
-                    and language != request.user.preferred_language):
-                request.user.set_preferred_language(language)
 
         if not (i18n_patterns_used and language_from_path):
             patch_vary_headers(response, ('Accept-Language',))

--- a/kn/base/media/bare.css
+++ b/kn/base/media/bare.css
@@ -101,6 +101,9 @@ a img {
 }
 
 /* taal kiezer */
-#footer #langpicker {
+#langpicker-form {
 	float: right;
+}
+#langpicker {
+	margin: 0 8px;
 }

--- a/kn/base/media/common.js
+++ b/kn/base/media/common.js
@@ -183,8 +183,8 @@ $(document).ready(function() {
     });
 
     // language picker
-    $('#langpicker').change(function() {
-        document.location = $(this).val();
+    $('#langpicker').change(function(e) {
+        e.target.form.submit();
     });
 });
 

--- a/kn/base/templates/base/bare.html
+++ b/kn/base/templates/base/bare.html
@@ -84,13 +84,17 @@
                         <small><a id="scrollUp" href="#"
                             >{% trans "Terug naar boven" %}</a></small>
                         {# Language picker #}
-                        <select id="langpicker">
-                        {% for code, name in LANGUAGES %}
-                        <option value="{% if code == "nl" %}/nl{% endif %}{% translate_url code %}"
-                            {% if code == LANGUAGE_CODE %}selected{% endif %}
-                                >{{ name }}</option>
-                        {% endfor %}{# code, name in LANGUAGES ... #}
-                        </select>
+                        <form method="POST" action="{% url "langpicker" %}"
+                            id="langpicker-form">
+                            {% csrf_token %}
+                            <select id="langpicker" name="language-url">
+                            {% for code, name in LANGUAGES %}
+                            <option value="{{ code }}:{% translate_url code %}"
+                                {% if code == LANGUAGE_CODE %}selected{% endif %}
+                                    >{{ name }}</option>
+                            {% endfor %}{# code, name in LANGUAGES ... #}
+                            </select>
+                        </form>
                         {# / Language picker #}
                     </div>
                 </div>

--- a/kn/base/urls.py
+++ b/kn/base/urls.py
@@ -1,0 +1,9 @@
+from django.conf.urls import url
+
+from kn.base import views
+
+urlpatterns = [
+    url(r'^langpicker$', views.langpicker, name='langpicker'),
+]
+
+# vim: et:sta:bs=2:sw=4:

--- a/kn/base/views.py
+++ b/kn/base/views.py
@@ -6,6 +6,8 @@ from django.core.servers.basehttp import FileWrapper
 from django.utils.translation import ugettext as _
 from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
+from django.utils.http import is_safe_url
+from django.core.exceptions import SuspiciousOperation
 
 def direct_to_folder(request, root, subdir):
     root = os.path.abspath(root)
@@ -28,6 +30,8 @@ def langpicker(request):
         if (hasattr(request, 'user') and request.user.is_authenticated()
                 and language != request.user.preferred_language):
             request.user.set_preferred_language(language)
+    if not is_safe_url(url):
+        raise SuspiciousOperation('redirect URL fails is_safe_url')
     return redirect(url)
 
 # vim: et:sta:bs=2:sw=4:

--- a/kn/base/views.py
+++ b/kn/base/views.py
@@ -5,6 +5,7 @@ import os
 from django.core.servers.basehttp import FileWrapper
 from django.utils.translation import ugettext as _
 from django.http import Http404, HttpResponse
+from django.shortcuts import redirect
 
 def direct_to_folder(request, root, subdir):
     root = os.path.abspath(root)
@@ -19,5 +20,14 @@ def direct_to_folder(request, root, subdir):
         raise Http404
     return HttpResponse(FileWrapper(open(p)),
             content_type=mimetypes.guess_type(p)[0])
+
+def langpicker(request):
+    language, url = request.POST['language-url'].split(':', 2)
+    if hasattr(request, 'session'):
+        request.session['_language'] = language
+        if (hasattr(request, 'user') and request.user.is_authenticated()
+                and language != request.user.preferred_language):
+            request.user.set_preferred_language(language)
+    return redirect(url)
 
 # vim: et:sta:bs=2:sw=4:

--- a/kn/urls.py
+++ b/kn/urls.py
@@ -30,6 +30,7 @@ urlpatterns += i18n_patterns(
     url(_(r'^moderatie/'), include('kn.moderation.urls')),
     url(_(r'^planning/'), include('kn.planning.urls')),
     url(_(r'^barco/'), include('kn.barco.urls')),
+    url(r'', include('kn.base.urls')),
     url(r'', include('kn.agenda.urls')),
     url(r'', include('kn.static.urls')),
     url(r'', include('kn.fotos.urls')),


### PR DESCRIPTION
Door naar een URL te gaan kon een taal aangepast worden in een account - dat lijkt me niet de bedoeling.

Ik heb het aangepast zodat alleen de taalswitcher onderin de taal in een account veranderd. Hiermee kun je niet 'per ongeluk' je account in een andere taal hebben.

Ik zie dat de taal pas 'geactiveerd' wordt na uitloggen en opnieuw inloggen. Ik neem aan dat dit komt door [`set_locale_on_login`](https://github.com/karpenoktem/kninfra/blob/master/kn/leden/entities.py#L1299). Misschien is het mooier als de taal van de sessie ondergeschikt is aan die in een account?