### PR TITLE
Kleine verbeteringen voor het fotoboek

### DIFF
--- a/kn/fotos/api.py
+++ b/kn/fotos/api.py
@@ -56,6 +56,7 @@ def entities_json(children, user):
             entry['description'] = child.description;
         if child._type == 'foto':
             entry['largeSize'] = child.get_cache_size('large')
+            entry['large2xSize'] = child.get_cache_size('large2x')
             entry['thumbnailSize'] = child.get_cache_size('thumb')
         elif child._type == 'album':
             album_foto = child.get_random_foto_for(user)

--- a/kn/fotos/media/close.svg
+++ b/kn/fotos/media/close.svg
@@ -4,7 +4,8 @@
    xmlns="http://www.w3.org/2000/svg"
    version="1.1"
    width="32"
-   height="32">
+   height="32"
+   viewBox="0 0 32 32">
   <path
      d="M 0,4 4,0 16,12 27,0 32,4 20,16 32,27 27,32 16,20 4,32 0,27 12,16 z"
      style="fill:#fff;stroke-width:0"/>

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -140,7 +140,8 @@ img.lazy {
     top: 0;
     left: 0;
     right: 0;
-    bottom: 0;
+    bottom: -80px; /* fix ugly border on rounding errors and while resizing */
+    padding-bottom: 80px;
     line-height: 1;
     font-family: sans-serif;
     font-size: 15px;
@@ -409,12 +410,6 @@ img.lazy {
 
 #foto .status {
     color: #aaa;
-}
-
-@media (max-height: 800px) {
-    #foto {
-        padding: 0;
-    }
 }
 
 .noscroll {

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -443,6 +443,10 @@
 
     $('.img', frame).on('load', this.onresize.bind(this));
     this.update_foto_src(foto);
+    if (foto.next) {
+      $('.prefetch-image', frame)
+        .attr('href', this.chooseFoto(foto.next).src);
+    }
 
     // Define these events here, not in show_sidebar, otherwise they fire twice.
     var sidebar = $('#foto .sidebar');

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -400,6 +400,9 @@
       delete this.foto.newTags;
     }
     foto = foto || null;
+    if (foto && foto.type != 'foto') {
+      foto = null;
+    }
     this.foto = foto;
     if (!foto) {
       this.apply_url(false);

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -562,7 +562,7 @@
           .appendTo(li);
       }
     }
-    if (newTags.length == 0) {
+    if (newTags.length == 0 && !fotos_admin) {
       tagList.html('<li><i>Geen tags</i></li>');
     }
     if (fotos_admin) {

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -885,8 +885,16 @@
     $(document).keydown(function(e) {
       if (!this.foto)
         return;
-      if (e.target.nodeName === 'INPUT')
-        return;
+      if (e.target.nodeName === 'INPUT') {
+        if (e.which == 27) { // Escape
+          e.target.blur();
+          return false;
+        }
+        if (e.target.value !== '') {
+          // Don't handle keys when editing a textbox.
+          return;
+        }
+      }
       // Escape
       if (e.which == 27) {
         this.change_foto(null);
@@ -910,6 +918,12 @@
       // ]
       if (e.which == 221) {
         this.rotate(90);
+        return false;
+      }
+      // T (add tag)
+      if (e.which == 84 && fotos_admin) {
+        this.open_sidebar();
+        $('#foto .tags input').focus();
         return false;
       }
     }.bind(this));

--- a/kn/fotos/media/next.svg
+++ b/kn/fotos/media/next.svg
@@ -4,7 +4,8 @@
    xmlns="http://www.w3.org/2000/svg"
    version="1.1"
    width="32"
-   height="32">
+   height="32"
+   viewBox="0 0 32 32">
   <path
      d="m 7.5,0 7,0 11,16 -11,16 -7,0 11,-16 z"
      style="fill:#fff;stroke-width:0"/>

--- a/kn/fotos/media/prev.svg
+++ b/kn/fotos/media/prev.svg
@@ -4,7 +4,8 @@
    xmlns="http://www.w3.org/2000/svg"
    version="1.1"
    width="32"
-   height="32">
+   height="32"
+   viewBox="0 0 32 32">
   <path
      d="m 25.5,0 -7,0 -11,16 11,16 7,0 -11,-16 z"
      style="fill:#fff;stroke-width:0"/>

--- a/kn/fotos/media/sidebar.svg
+++ b/kn/fotos/media/sidebar.svg
@@ -4,7 +4,8 @@
    xmlns="http://www.w3.org/2000/svg"
    version="1.1"
    width="32"
-   height="32">
+   height="32"
+   viewBox="0 0 32 32">
   <path
      d="M 2,7 30,7 M 2,16 30,16 M 2,25 30,25"
      style="stroke:#fff;stroke-width:4;stroke-linecap:round"/>

--- a/kn/fotos/templates/fotos/fotos.html
+++ b/kn/fotos/templates/fotos/fotos.html
@@ -10,7 +10,7 @@
 <script type="text/javascript"
         src="{{ MEDIA_URL }}base/jquery-ui-1.8.22/the.js" defer></script>
 {% endif %}
-<script type="text/javascript" src="{{ MEDIA_URL }}fotos/fotos.js?v=2"></script>
+<script type="text/javascript" src="{{ MEDIA_URL }}fotos/fotos.js?v=3"></script>
 <script type="text/javascript">
 'use strict';
 expandHeader = false;
@@ -42,7 +42,7 @@ if ('srcset' in (new Image())) {
 {% block styles %}
 {{ block.super }}
 <link rel="stylesheet" type="text/css"
-        href="{{ MEDIA_URL }}fotos/fotos.css" />
+        href="{{ MEDIA_URL }}fotos/fotos.css?v=3" />
 {% if fotos_admin %}
 <link rel="stylesheet" type="text/css"
     deferred-href="{{ MEDIA_URL }}base/jquery-ui-1.8.22/the.css"/>

--- a/kn/fotos/templates/fotos/fotos.html
+++ b/kn/fotos/templates/fotos/fotos.html
@@ -137,5 +137,6 @@ dit album zien.{% endblocktrans %}</p>
       <a class="orig">{% trans "origineel" %}</a>
     </div>
   </div>
+  <link rel="prefetch" as="image" class="prefetch-image"/>
 </div>
 {% endblock body %}


### PR DESCRIPTION
Dit is een verzameling commits, ik wilde niet voor elke een aparte pull request maken.

De belangrijkste wijziging is dat de grootte van foto's nu anders berekend wordt, waarmee zoveel mogelijk ruimte op het scherm gebruikt wordt. Ook wordt rekening gehouden met de pixeldichtheid van het scherm. En hiermee wordt het preloaden van de volgende afbeelding makkelijker (dat werkt helaas niet in Firefox en vermoedelijk niet in IE/Edge, werkt wel in Chrome).