### PR TITLE
Verwijder genderregistratie

### DIFF
--- a/kn/leden/entities.py
+++ b/kn/leden/entities.py
@@ -38,7 +38,6 @@ ecol = db['entities']   # entities: users, group, tags, studies, ...
 #   "person" : { "given" : null,
 #                "family" : "Jansen",
 #                "nick" : "Giedo",
-#                "gender" : "m",
 #                "dateOfBirth" : ISODate("..."),
 #                "titles" : [ ] },
 #   "is_active" : 0,
@@ -1133,9 +1132,6 @@ class User(Entity):
     @property
     def last_name(self):
         return self._data.get('person',{}).get('family')
-    @property
-    def gender(self):
-        return self._data.get('person',{}).get('gender')
     @property
     def preferred_language(self):
         return self._data.get('preferred_language', settings.LANGUAGE_CODE)

--- a/kn/leden/forms.py
+++ b/kn/leden/forms.py
@@ -67,9 +67,6 @@ class AddUserForm(forms.Form):
                         'placeholder': _('bijv.: Vaart, van der')}))
     username = forms.CharField(label=_("Gebruikersnaam"),
                     validators=[validate_username])
-    gender = forms.ChoiceField(label=_("Geslacht"),
-                        choices=(('m', _('Man')),
-                                 ('v', _('Vrouw'))))
     email = forms.EmailField(label=_("E-Mail adres"))
     dateOfBirth = forms.DateField(label=_("Geboortedatum"))
     addr_street = forms.CharField(label=_("Straatnaam"))

--- a/kn/leden/templates/leden/welcome.mail.txt
+++ b/kn/leden/templates/leden/welcome.mail.txt
@@ -33,11 +33,9 @@ Bij voorbaat dank,
 -----------------------------------------------------------
 
   {% blocktrans with first_name=u.first_name last_name=u.last_name \
-                   gender=u.gender dateOfBirth=u.dateOfBirth.date \
-                   names=u.names|join:" " %}\
+                   dateOfBirth=u.dateOfBirth.date names=u.names|join:" " %}\
 Voornaam              {{ first_name }}
   Achternaam            {{ last_name }}
-  Geslacht              {{ gender }}
   Geboortedatum         {{ dateOfBirth }}
   Gebruikersnamen       {{ names }}
 {% endblocktrans %}

--- a/kn/leden/views.py
+++ b/kn/leden/views.py
@@ -461,7 +461,6 @@ def rauth(request):
             properties = {
                 'firstname': user.first_name,
                 'lastname': user.last_name,
-                'gender': user.gender,
                 'fullname': user.full_name,
                 'groups': list(user.cached_groups_names)
             }
@@ -522,7 +521,6 @@ def secr_add_user(request):
                     'nick': fd['first_name'],
                     'given': None,
                     'family': fd['last_name'],
-                    'gender': fd['gender'],
                     'dateOfBirth': date_to_dt(
                         fd['dateOfBirth'])
                 },
@@ -554,7 +552,6 @@ def secr_add_user(request):
             u.save()
             # Then, add the relations.
             groups = ['leden']
-            groups.append({'m': 'mannen', 'v': 'vrouwen'}.get(fd['gender']))
             if fd['incasso']:
                 groups.append('incasso')
             else:

--- a/utils/leden/check-email.template
+++ b/utils/leden/check-email.template
@@ -15,7 +15,6 @@ Personalia  {{ u.full_name }}
 
   Voornaam              {{ u.first_name }}
   Achternaam            {{ u.last_name }}
-  Geslacht              {{ u.gender }}
   Geboortedatum         {{ u.dateOfBirth.date }}
   Gebruikersnamen       {{ u.names|join:" " }}
 

--- a/utils/leden/check-members.py
+++ b/utils/leden/check-members.py
@@ -59,8 +59,6 @@ def check_members(members):
             print "%s: no empty addr_number" % m.username
         if m.addr_city == '':
             print "%s: no empty addr_city" % m.username
-        if not m.gender in ('m', 'v'):
-            print "%s: gender not in {m, v}" % m.username
         if m.telephone is None:
             print "%s: telephone is None" % m.username
         elif m.telephone == '':

--- a/utils/leden/detailedList.py
+++ b/utils/leden/detailedList.py
@@ -20,7 +20,6 @@ for u in args_to_users(args):
     data.append((
         u.first_name,
         u.last_name,
-        u.gender,
         u.studentNumber,
         u.institute,
         u.study,

--- a/utils/leden/welcome-email.py
+++ b/utils/leden/welcome-email.py
@@ -17,9 +17,6 @@ def welcome_email():
              'firstName': m.first_name,
              'lastName': m.last_name,
              'fullName': m.full_name(),
-             'gender': ('onbekend' if m.gender is None
-                else {'m': 'man',
-                      'v': 'vrouw'}.get(m.gender, '?')),
              'dateOfBirth': ('onbekend' if m.dateOfBirth is None
                 else str(m.dateOfBirth)),
              'dateJoined': ('onbekend' if m.dateJoined is None

--- a/utils/leden/welcome-email.template
+++ b/utils/leden/welcome-email.template
@@ -6,7 +6,6 @@ Van jouw inschrijfformulier hebben wij het volgende overgenomen.
 
  voornaam              %(firstName)s
  achternaam            %(lastName)s
- geslacht              %(gender)s
  geboortedatum         %(dateOfBirth)s
  datum van toetreding  %(dateJoined)s
 


### PR DESCRIPTION
Dit heb ik getest:

* het aanmaken van een nieuw account (inclusief controle email)
* jaarlijkse controle email
* `reset-database`
* `check-members.py`
* `detailedList.py`

Hiervan werkten de laatste twee scripts niet, maar dat komt denk ik doordat het hele oude code is die niet meer functioneert (ze importeren `kn.leden.models`, dat niet bestaat), dus ik vermoed dat dat bestand (net als meer scripts in die map) eigenlijk gewoon weg kan.

Er zit ook een wijziging in voor rauth. Ik heb die niet getest. Volgens mij is de enige plek waar deze code gebruikt wordt het oude (PHP) fotoboek, dus ik denk eigenlijk dat heel rauth verwijderd mag worden. Of zou het nog in het forum gebruikt worden?

Ik stuur zo een mail met meer uitleg.