### PR TITLE
Fix API when using a GET request without parameters

### DIFF
--- a/kn/fotos/api.py
+++ b/kn/fotos/api.py
@@ -6,14 +6,12 @@ from kn.base.http import JsonHttpResponse
 from django.core.exceptions import PermissionDenied
 
 def view(request):
-    data = json.loads(request.REQUEST.get('data', {}))
+    data = json.loads(request.REQUEST.get('data', '{}'))
     action = data.get('action')
-    handler = ACTION_HANDLER_MAP.get(action,
-                    ACTION_HANDLER_MAP[None])
+    handler = ACTION_HANDLER_MAP.get(action, None)
+    if handler is None:
+        return JsonHttpResponse({'error': 'No such action'}, status=400)
     return JsonHttpResponse(handler(data, request))
-
-def no_such_action(data, request):
-    return {'error': 'No such action'}
 
 def album_parents_json(album):
     json_parents = {}
@@ -223,7 +221,6 @@ ACTION_HANDLER_MAP = {
         'set-metadata': _set_metadata,
         'remove': _remove,
         'search': _search,
-        None: no_such_action,
         }
 
 # vim: et:sta:bs=2:sw=4:

--- a/kn/leden/api.py
+++ b/kn/leden/api.py
@@ -12,14 +12,12 @@ from kn.leden.utils import find_name_for_user, parse_date
 
 @login_required
 def view(request):
-    data = json.loads(request.REQUEST.get('data', {}))
+    data = json.loads(request.REQUEST.get('data', '{}'))
     action = data.get('action')
-    handler = ACTION_HANDLER_MAP.get(action,
-                    ACTION_HANDLER_MAP[None])
+    handler = ACTION_HANDLER_MAP.get(action, None)
+    if handler is None:
+        return JsonHttpResponse({'error': 'No such action'}, status=400)
     return JsonHttpResponse(handler(data, request))
-
-def no_such_action(data, request):
-    return {'error': 'No such action'}
 
 
 def _humanName_of_entity(e):
@@ -249,7 +247,6 @@ ACTION_HANDLER_MAP = {
         'entity_end_study':  entity_end_study,
         'get_last_synced':  get_last_synced,
         'adduser_suggest_username': adduser_suggest_username,
-        None: no_such_action,
         }
 
 # vim: et:sta:bs=2:sw=4:


### PR DESCRIPTION
Dit zijn eigenlijk 2 wijzigingen:

1. Zorg dat er geen `500` error wordt geretourneerd bij een GET request. Dit gebeurde vooral bij Googlebot (`TypeError: expected string or buffer`).
2. Retourneer iets anders dan `200` als de action niet wordt gevonden.