### PR TITLE
Fix open() calls in Python 3

### DIFF
--- a/kn/base/views.py
+++ b/kn/base/views.py
@@ -21,7 +21,7 @@ def direct_to_folder(request, root, subdir):
         raise ValueError(_("%s is een map --- geen bestand") % p)
     if os.stat(p).st_mode & 4 != 4:
         raise Http404
-    return HttpResponse(FileWrapper(open(p)),
+    return HttpResponse(FileWrapper(open(p, 'rb')),
                         content_type=mimetypes.guess_type(p)[0])
 
 

--- a/kn/browser/views.py
+++ b/kn/browser/views.py
@@ -43,7 +43,7 @@ def homedir(request, root, subdir, path):
         # world read access?
         if os.stat(p).st_mode & 4 != 4:
             raise Http404
-        response = HttpResponse(FileWrapper(open(p)),
+        response = HttpResponse(FileWrapper(open(p, 'rb')),
                                 content_type=mimetypes.guess_type(p)[0])
         response['Content-Length'] = os.path.getsize(p)
         response['Content-Disposition'] = 'attachment'

--- a/kn/fotos/views.py
+++ b/kn/fotos/views.py
@@ -133,7 +133,7 @@ def cache(request, cache, path):
     if not entity.may_view(None):
         # not publicly cacheable
         cc = 'private, ' + cc
-    resp = HttpResponse(FileWrapper(open(entity.get_cache_path(cache))),
+    resp = HttpResponse(FileWrapper(open(entity.get_cache_path(cache), 'rb')),
                         content_type=entity.get_cache_mimetype(cache))
     resp['Content-Length'] = str(st.st_size)
     resp['Last-Modified'] = lm

--- a/kn/leden/graphs.py
+++ b/kn/leden/graphs.py
@@ -31,7 +31,7 @@ def view(request, graph, ext):
             > datetime.timedelta(seconds=timeout)):
         update(default_storage.path(
             os.path.join(settings.GRAPHS_PATH, graph)))
-    return HttpResponse(FileWrapper(default_storage.open(path)),
+    return HttpResponse(FileWrapper(default_storage.open(path, 'rb')),
                         content_type=mimetypes.guess_type(path)[0])
 
 

--- a/kn/leden/views.py
+++ b/kn/leden/views.py
@@ -370,7 +370,7 @@ def user_smoel(request, name):
     try:
         img = default_storage.open(path.join(
             settings.SMOELEN_PHOTOS_PATH,
-            str(user.name)) + ".jpg")
+            str(user.name)) + ".jpg", 'rb')
     except IOError:
         raise Http404
     return HttpResponse(FileWrapper(img), content_type="image/jpeg")
@@ -862,7 +862,7 @@ def ik_openvpn_download(request, filename):
     if not default_storage.exists(p):
         raise Http404
     response = HttpResponse(
-        FileWrapper(default_storage.open(p)),
+        FileWrapper(default_storage.open(p, 'rb')),
         content_type=mimetypes.guess_type(default_storage.path(p))[0]
     )
     response['Content-Length'] = default_storage.size(p)


### PR DESCRIPTION
In Python 3, it really matters whether a file is opened as text or as binary.

Technically it's not needed on default_storage.open as it defaults to 'rb', but I've added it for consistency and to avoid any doubt.