### PR TITLE
Mooiere switch tussen foto's

### DIFF
--- a/kn/fotos/api.py
+++ b/kn/fotos/api.py
@@ -139,6 +139,7 @@ def _set_metadata(data, request):
         entity.set_rotation(rotation, save=False)
 
         result['largeSize'] = entity.get_cache_size('large')
+        result['large2xSize'] = entity.get_cache_size('large2x')
 
     if entity._type in ['foto', 'video']:
         if 'description' not in data:
@@ -160,6 +161,7 @@ def _set_metadata(data, request):
         entity.set_tags(tags, save=True)
 
         result['thumbnailSize'] = entity.get_cache_size('thumb')
+        result['thumbnail2xSize'] = entity.get_cache_size('thumb2x')
 
     entity.set_title(title, save=False)
 

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -244,21 +244,9 @@ img.lazy {
     will-change: transform, opacity;
 }
 
-#foto .images img.right,
-#foto .images img.left,
 #foto .images img.settle {
     /* keep time up to date with fotos.js */
     transition: opacity 200ms linear, transform 200ms ease;
-}
-
-#foto .images img.right { /* a bit to the right */
-    opacity: 0;
-    transform: translateX(20px);
-}
-
-#foto .images img.left { /* a bit to the left */
-    opacity: 0;
-    transform: translateX(-20px);
 }
 
 #foto .img {

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -241,6 +241,7 @@ img.lazy {
     width: 100%;
     height: 100%;
     position: relative;
+    touch-action: pan-y pinch-zoom; /* not sure whether this actually does anything */
 }
 
 #foto .image-wrapper {

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -239,30 +239,24 @@ img.lazy {
     touch-action: pan-y pinch-zoom; /* not sure whether this actually does anything */
 }
 
-#foto .image-wrapper {
+#foto .images img {
     position: absolute;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    opacity: 1;
-    will-change: transform;
+    will-change: transform, opacity;
 }
 
-#foto .image-wrapper.right,
-#foto .image-wrapper.left,
-#foto .image-wrapper.settle {
+#foto .images img.right,
+#foto .images img.left,
+#foto .images img.settle {
     /* keep time up to date with fotos.js */
     transition: opacity 200ms linear, transform 200ms linear;
 }
 
-#foto .image-wrapper.right { /* a bit to the right */
+#foto .images img.right { /* a bit to the right */
     opacity: 0;
     transform: translateX(20px);
 }
 
-#foto .image-wrapper.left { /* a bit to the left */
+#foto .images img.left { /* a bit to the left */
     opacity: 0;
     transform: translateX(-20px);
 }

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -168,6 +168,7 @@ img.lazy {
     background: none; /* FF mobile */
     opacity: 0;
     transition: opacity 0.5s;
+    will-change: opacity;
 }
 #foto.show-nav a.nav,
 #foto.sidebar a.nav {
@@ -236,7 +237,6 @@ img.lazy {
     width: 100%;
     height: 100%;
     position: relative;
-    touch-action: pan-y pinch-zoom; /* not sure whether this actually does anything */
 }
 
 #foto .images img {
@@ -248,7 +248,7 @@ img.lazy {
 #foto .images img.left,
 #foto .images img.settle {
     /* keep time up to date with fotos.js */
-    transition: opacity 200ms linear, transform 200ms linear;
+    transition: opacity 200ms linear, transform 200ms ease;
 }
 
 #foto .images img.right { /* a bit to the right */

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -130,7 +130,7 @@ img.lazy {
 }
 
 #foto {
-    display: none;
+    display: none; /* on show: flex */
     z-index: 10;
     position: fixed;
     top: 0;
@@ -143,11 +143,6 @@ img.lazy {
     font-size: 15px;
     color: white;
     background-color: black;
-}
-#foto > .foto-frame {
-    width: 100%;
-    height: 100%;
-    display: flex;
 }
 
 #foto img {

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -142,7 +142,6 @@ img.lazy {
     font-family: sans-serif;
     font-size: 15px;
     color: white;
-    background-color: black; /* IE8 */
     background-color: rgba(0,0,0,0.95);
 }
 #foto > .foto-frame {
@@ -202,7 +201,6 @@ img.lazy {
 #foto .prev img,
 #foto .next img {
     position: absolute;
-    top: 45%; /* IE8 */
     top: calc(50% - 16px);
     padding: 7px 0;
 }

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -248,13 +248,13 @@ img.lazy {
     align-items: center;
     opacity: 1;
     will-change: transform;
-    transform: scale(1) translateX(0);
 }
 
 #foto .image-wrapper.right,
 #foto .image-wrapper.left,
 #foto .image-wrapper.settle {
-    transition: all 200ms linear; /* keep up to date with fotos.js */
+    /* keep time up to date with fotos.js */
+    transition: opacity 200ms linear, transform 200ms linear;
 }
 
 #foto .image-wrapper.right { /* a bit to the right */

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -142,7 +142,7 @@ img.lazy {
     font-family: sans-serif;
     font-size: 15px;
     color: white;
-    background-color: rgba(0,0,0,0.95);
+    background-color: black;
 }
 #foto > .foto-frame {
     width: 100%;
@@ -250,9 +250,15 @@ img.lazy {
     display: flex;
     justify-content: center;
     align-items: center;
-    opacity: 1;
     left: 0;
-    transition: all 200ms linear;
+    opacity: 1;
+    transform: scale(1);
+}
+
+#foto .image-wrapper.right,
+#foto .image-wrapper.left,
+#foto .image-wrapper.settle {
+    transition: all 200ms linear; /* keep up to date with fotos.js */
 }
 
 #foto .image-wrapper.right { /* a bit to the right */

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -250,9 +250,9 @@ img.lazy {
     display: flex;
     justify-content: center;
     align-items: center;
-    left: 0;
     opacity: 1;
-    transform: scale(1);
+    will-change: transform;
+    transform: scale(1) translateX(0);
 }
 
 #foto .image-wrapper.right,
@@ -263,17 +263,17 @@ img.lazy {
 
 #foto .image-wrapper.right { /* a bit to the right */
     opacity: 0;
-    left: 20px;
+    transform: translateX(20px);
 }
 
 #foto .image-wrapper.left { /* a bit to the left */
     opacity: 0;
-    left: -20px;
+    transform: translateX(-20px);
 }
 
 #foto .img {
     display: block;
-    background-color: black;
+    background-color: #555; /* 'image is loading' */
 }
 
 #foto .sidebar {

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -129,10 +129,6 @@ img.lazy {
     visibility: hidden;
 }
 
-.template {
-    display: none;
-}
-
 #foto {
     display: none;
     z-index: 10;
@@ -152,7 +148,6 @@ img.lazy {
 #foto > .foto-frame {
     width: 100%;
     height: 100%;
-    text-align: center; /* fallback for flexbox */
     display: flex;
 }
 
@@ -244,23 +239,27 @@ img.lazy {
 }
 
 
-#foto .image-wrapper {
-    flex-grow: 1;
+#foto .images {
+    width: 100%;
+    height: 100%;
     position: relative;
-    height: 100%; /* fallback */
-    width: calc(100% - 220px); /* fallback */
-    display: inline-block;
+}
+
+#foto .image-wrapper {
+    position: absolute;
+    width: 100%;
+    height: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
 }
 
 #foto .img {
+    display: block;
     background-color: black;
 }
 
 #foto .sidebar {
-    float: right; /* fallback */
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -281,9 +280,6 @@ img.lazy {
 /* Keep up to date with fotos.js! (onresize) */
 /* Mobile view */
 @media (max-width: 700px) {
-    #foto .image-wrapper {
-        width: 100%; /* fallback */
-    }
     #foto .sidebar {
         position: absolute;
         top: 44px;

--- a/kn/fotos/media/fotos.css
+++ b/kn/fotos/media/fotos.css
@@ -252,6 +252,19 @@ img.lazy {
     display: flex;
     justify-content: center;
     align-items: center;
+    opacity: 1;
+    left: 0;
+    transition: all 200ms linear;
+}
+
+#foto .image-wrapper.right { /* a bit to the right */
+    opacity: 0;
+    left: 20px;
+}
+
+#foto .image-wrapper.left { /* a bit to the left */
+    opacity: 0;
+    left: -20px;
 }
 
 #foto .img {

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -454,27 +454,32 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
     // Create the new photo
     var img = $('<img class="img">');
     img.attr('data-name', foto.name);
-    img.addClass(direction);
     img.attr('state', 'current');
     img.attr('src', this.chooseFoto(foto).src);
+    if (direction) {
+      img.addClass(direction);
+      setTimeout(function() {
+        // don't disturb dragging of the photo
+        img.removeClass('settle');
+      }.bind(this), SWITCH_DURATION);
+    }
     $('.images', frame).append(img);
-    setTimeout(function() {
-      // Start the animation immediately (after 1ms)
-      // Preferably this should be done in the 'loadstart' event, but that sadly
-      // hasn't been implemented in browsers yet.
-      img.addClass('settle');
-      img.removeClass(direction);
-    }.bind(this), 1);
-    setTimeout(function() {
-      // don't disturb dragging of the photo
-      img.removeClass('settle');
-    }.bind(this), SWITCH_DURATION);
 
     this.update_foto_frame(foto, direction);
 
     this.resize();
     $('html').addClass('noscroll');
     frame.css('display', 'flex'); // show
+
+    if (direction) {
+      // Force a reflow
+      img.css('opacity');
+      // Start the animation immediately (after the reflow).
+      // Preferably this should be done in the 'loadstart' event, but that
+      // sadly hasn't been implemented in browsers yet.
+      img.addClass('settle');
+      img.removeClass(direction);
+    }
   };
 
   KNF.prototype.update_foto_frame = function(foto, direction) {

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -722,7 +722,8 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
         next.attr('state', 'current');
         setTimeout(function() {
           $('.images img[state=prev]', frame)
-            .removeClass('settle');
+            .removeClass('settle')
+            .css('transform', 'translateX(-9999px)');
           $('.images img[state=current]', frame)
             .removeClass('settle');
           // Create the next image (to cache)

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -789,8 +789,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
           translateY: this.zoom_previous.translateY + translateY,
           scale: this.zoom_previous.scale,
         };
-        var current = $('#foto .images img[state=current]');
-        current.css('transform', 'translate(' + this.zoom_current.translateX + 'px, ' + this.zoom_current.translateY + 'px) scale(' + this.zoom_current.scale + ')');
+        this.apply_transform(this.zoom_current, false);
       }
       return;
     }

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -475,13 +475,22 @@
     }.bind(this), 1);
     this.update_foto_src(foto);
 
-    if (direction == 'left' && foto.prev) {
+    $('.preload-image', frame).remove(); // remove old preloaders
+    var preloadHref = null;
+    if (direction == 'left' && foto.prev && foto.prev.type === 'foto') {
       // user will likely move to the left again
-      $('.prefetch-image', frame)
-        .attr('href', this.chooseFoto(foto.prev).src);
-    } else { // right or undefined - user will likely move to the right
-      $('.prefetch-image', frame)
-        .attr('href', this.chooseFoto(foto.next).src);
+      preloadHref = this.chooseFoto(foto.prev).src;
+    } else if (foto.next && foto.next.type === 'foto') {
+      // user will likely move to the right again
+      preloadHref = this.chooseFoto(foto.next).src;
+    }
+    if (preloadHref) {
+      var preload = $('<link rel="preload" as="image" class="preload-image"/>');
+      preload.attr('href', preloadHref);
+      preload.on('load', function(e) {
+        console.log('preload loaded:', e.target.href);
+      });
+      frame.append(preload);
     }
 
     $('#foto').show();

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -436,35 +436,33 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
     }
 
     // Remove old images
-    $('.image-wrapper', frame).each(function(i, wrapper) {
-      wrapper = $(wrapper);
-      if (wrapper.hasClass('left') || wrapper.hasClass('right')) return;
-      wrapper.addClass(reverseDirection);
-      wrapper.attr('state', 'gone'); // don't use this image anymore
+    $('.images img', frame).each(function(i, img) {
+      img = $(img);
+      if (img.hasClass('left') || img.hasClass('right')) return;
+      img.addClass(reverseDirection);
+      img.attr('state', 'gone'); // don't use this image anymore
       setTimeout(function() {
-        wrapper.remove();
+        img.remove();
       }.bind(this), SWITCH_DURATION);
     }.bind(this));
 
     // Create the new photo
     var img = $('<img class="img">');
-    var wrapper = $('<div class="image-wrapper">');
-    wrapper.attr('data-name', foto.name);
-    wrapper.addClass(direction);
-    wrapper.attr('state', 'current');
+    img.attr('data-name', foto.name);
+    img.addClass(direction);
+    img.attr('state', 'current');
     img.attr('src', this.chooseFoto(foto).src);
-    wrapper.append(img);
-    $('.images', frame).append(wrapper);
+    $('.images', frame).append(img);
     setTimeout(function() {
       // Start the animation immediately (after 1ms)
       // Preferably this should be done in the 'loadstart' event, but that sadly
       // hasn't been implemented in browsers yet.
-      wrapper.addClass('settle');
-      wrapper.removeClass(direction);
+      img.addClass('settle');
+      img.removeClass(direction);
     }.bind(this), 1);
     setTimeout(function() {
       // don't disturb dragging of the photo
-      wrapper.removeClass('settle');
+      img.removeClass('settle');
     }.bind(this), SWITCH_DURATION);
 
     this.update_foto_frame(foto, direction);
@@ -635,18 +633,16 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
 
       this.swype_moved = moved;
 
-      var current = $('.image-wrapper[state=current]', frame);
-      var prev = $('.image-wrapper[state=prev]', frame); // possibly 0
-      var next = $('.image-wrapper[state=next]', frame); // possibly 0
+      var current = $('.images img[state=current]', frame);
+      var prev = $('.images img[state=prev]', frame); // possibly 0
+      var next = $('.images img[state=next]', frame); // possibly 0
 
       if (moved < 0) {
         // Preview next image
         if (next.length == 0) {
-          next = $('<div class="image-wrapper"><img class="img"></div>');
+          next = $('<img class="img" state="next"/>');
           next.attr('data-name', this.foto.next.name);
-          next.attr('state', 'next');
-          $('img', next)
-            .attr('src', this.chooseFoto(this.foto.next).src);
+          next.attr('src', this.chooseFoto(this.foto.next).src);
           $('.images', frame).prepend(next);
           this.onresize();
         }
@@ -666,11 +662,9 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
       if (moved > 0) {
         // Preview previous image
         if (prev.length == 0) {
-          prev = $('<div class="image-wrapper"><img class="img"></div>');
+          prev = $('<img class="img" state="prev"/>');
           prev.attr('data-name', this.foto.prev.name);
-          prev.attr('state', 'prev');
-          $('img', prev)
-            .attr('src', this.chooseFoto(this.foto.prev).src);
+          prev.attr('src', this.chooseFoto(this.foto.prev).src);
           $('.images', frame).append(prev);
           this.onresize();
         }
@@ -703,9 +697,9 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
       this.swype_start = null;
       this.swype_moved = null;
 
-      var current = $('.image-wrapper[state=current]', frame).last();
-      var next = $('.image-wrapper[state=next]', frame); // possibly 0
-      var prev = $('.image-wrapper[state=prev]', frame); // possibly 0
+      var current = $('.images img[state=current]', frame).last();
+      var next = $('.images img[state=next]', frame); // possibly 0
+      var prev = $('.images img[state=prev]', frame); // possibly 0
 
       if (moved < this.maxWidth / -16 && this.foto.next && this.foto.next.type != 'album') {
         console.log('end: next');
@@ -726,21 +720,19 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
         current.attr('state', 'prev');
         next.attr('state', 'current');
         setTimeout(function() {
-          $('.image-wrapper[state=prev]', frame)
+          $('.images img[state=prev]', frame)
             .removeClass('settle');
-          $('.image-wrapper[state=current]', frame)
+          $('.images img[state=current]', frame)
             .removeClass('settle');
           // Create the next image (to cache)
           // not sure whether it actually helps...
           // TODO: code duplication
           if (this.foto.next && this.foto.next.type != 'album' &&
-              $('.image-wrapper[state=next]', frame).length == 0) {
-            var next = $('<div class="image-wrapper"><img class="img"></div>');
+              $('.images img[state=next]', frame).length == 0) {
+            var next = $('<img class="img" state="next">');
             next.attr('data-name', this.foto.next.name);
-            next.attr('state', 'next');
             next.css('transform', 'translateX(9999px)'); // off-screen
-            $('img', next)
-              .attr('src', this.chooseFoto(this.foto.next).src);
+            next.attr('src', this.chooseFoto(this.foto.next).src);
             $('.images', frame).prepend(next);
             this.onresize();
           }
@@ -767,20 +759,18 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
         current.attr('state', 'next');
         prev.attr('state', 'current');
         setTimeout(function() {
-          $('.image-wrapper[state=current]', frame)
+          $('.images img[state=current]', frame)
             .removeClass('settle');
-          $('.image-wrapper[state=next]', frame)
+          $('.images img[state=next]', frame)
             .removeClass('settle');
           // cache the previous image in case the user goes back one more
           // TODO: code duplication
           if (this.foto.prev && this.foto.prev.type != 'album' &&
-              $('.image-wrapper[state=prev]', frame).length == 0) {
-            var prev = $('<div class="image-wrapper"><img class="img"></div>');
+              $('.images img[state=prev]', frame).length == 0) {
+            var prev = $('<img class="img" state="prev">');
             prev.attr('data-name', this.foto.prev.name);
-            prev.attr('state', 'prev');
             prev.css('transform', 'translateX(9999px)'); // off-screen
-            $('img', prev)
-              .attr('src', this.chooseFoto(this.foto.prev).src);
+            prev.attr('src', this.chooseFoto(this.foto.prev).src);
             $('.images', frame).append(prev);
             this.onresize();
           }
@@ -1095,14 +1085,15 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
   };
 
   KNF.prototype.onresize = function() {
-    $('#foto .image-wrapper:not([state=gone])').each(function(i, wrapper) {
-      wrapper = $(wrapper);
-      console.log('updating', wrapper.attr('data-name'));
-      var img = $('img', wrapper);
-      var foto = this.fotos[this.path].children[wrapper.attr('data-name')];
+    $('#foto .images img:not([state=gone])').each(function(i, img) {
+      img = $(img);
+      console.log('updating', img.attr('data-name'));
+      var foto = this.fotos[this.path].children[img.attr('data-name')];
       var props = this.chooseFoto(foto);
       img.css({'width': props.width,
-               'height': props.height});
+               'height': props.height,
+               'left': (this.maxWidth-props.width)/2,
+               'top': (this.maxHeight-props.height)/2});
       // switch to 2x if needed (but don't switch back for this photo)
       if (props.src == this.foto.large2x &&
           img.attr('src') != this.foto.large2x) {

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -692,8 +692,6 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
   };
 
   KNF.prototype.touchstart = function (e) {
-    if (this.sidebar) return;
-
     // Ignore the third (or more) finger
     if (e.originalEvent.touches.length > 2) return;
 
@@ -784,7 +782,6 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
   };
 
   KNF.prototype.touchmove = function(e) {
-    if (this.sidebar) return;
     if (this.swype_start === null && this.zoom_previous === null) return;
 
     e.preventDefault();
@@ -928,8 +925,6 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
   };
 
   KNF.prototype.touchend = function(e) {
-    if (this.sidebar) return;
-
     // ignore lifting the third (or more) finger
     if (e.originalEvent.touches.length > 1) return;
 

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -415,7 +415,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
     if (!foto) {
       // close photo frame if there is one
       if (this.foto) {
-        frame.hide();
+        frame.css('display', 'none'); // hide
         $('html').removeClass('noscroll');
         delete this.foto.newTags;
         this.foto = null;
@@ -471,7 +471,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
 
     this.onresize();
     $('html').addClass('noscroll');
-    frame.show();
+    frame.css('display', 'flex'); // show
   };
 
   KNF.prototype.update_foto_frame = function(foto, direction) {

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -537,12 +537,12 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
   KNF.prototype.init_foto_frame = function() {
     var frame = $('#foto');
     $('.close', frame)
-        .on('touchstart', function() {
+        .on('click', function() {
           this.change_foto(null);
           return false;
         }.bind(this));
     $('.open-sidebar', frame)
-        .on('touchstart', function(e) {
+        .on('click', function(e) {
           if (this.sidebar) {
             this.close_sidebar();
           } else {

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -707,7 +707,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
       var next = $('.image-wrapper[state=next]', frame); // possibly 0
       var prev = $('.image-wrapper[state=prev]', frame); // possibly 0
 
-      if (moved < this.maxWidth / -6 && this.foto.next && this.foto.next.type != 'album') {
+      if (moved < this.maxWidth / -16 && this.foto.next && this.foto.next.type != 'album') {
         console.log('end: next');
         // next image
         next.addClass('settle');
@@ -748,7 +748,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
 
         this.update_foto_frame(this.foto.next, 'right');
 
-      } else if (moved > this.maxWidth / 6 && this.foto.prev && this.foto.prev.type != 'album') {
+      } else if (moved > this.maxWidth / 16 && this.foto.prev && this.foto.prev.type != 'album') {
         console.log('prev', prev);
         // previous image
         console.log('end: prev');

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -440,30 +440,33 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
       reverseDirection = 'right';
     }
 
-    // Remove old images
-    $('.images img', frame).each(function(i, img) {
-      img = $(img);
-      if (img.hasClass('left') || img.hasClass('right')) return;
-      img.addClass(reverseDirection);
-      img.attr('state', 'gone'); // don't use this image anymore
-      setTimeout(function() {
-        img.remove();
-      }.bind(this), SWITCH_DURATION);
-    }.bind(this));
-
-    // Create the new photo
-    var img = $('<img class="img">');
-    img.attr('data-name', foto.name);
-    img.attr('state', 'current');
-    img.attr('src', this.chooseFoto(foto).src);
-    if (direction) {
-      img.addClass(direction);
-      setTimeout(function() {
-        // don't disturb dragging of the photo
-        img.removeClass('settle');
-      }.bind(this), SWITCH_DURATION);
+    // Remove previous image
+    var prev = $('#foto .images img[state=prev]');
+    var current = $('#foto .images img[state=current]');
+    var next = $('#foto .images img[state=next]');
+    if (prev.length) {
+      prev.remove();
+      prev = null;
     }
-    $('.images', frame).append(img);
+    current.addClass(reverseDirection);
+    current.attr('state', 'prev');
+    prev = current;
+    current = next;
+
+    // Create the new photo - if swyping hasn't already created it.
+    if (!current.length) {
+      var current = $('<img class="img" state="current">');
+      current.attr('data-name', foto.name);
+      current.attr('src', this.chooseFoto(foto).src);
+      if (direction) {
+        current.addClass(direction);
+        setTimeout(function() {
+          // don't disturb dragging of the photo
+          current.removeClass('settle');
+        }.bind(this), SWITCH_DURATION);
+      }
+      $('.images', frame).append(current);
+    }
 
     this.update_foto_frame(foto, direction);
 
@@ -473,12 +476,12 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
 
     if (direction) {
       // Force a reflow
-      img.css('opacity');
+      current.css('opacity');
       // Start the animation immediately (after the reflow).
       // Preferably this should be done in the 'loadstart' event, but that
       // sadly hasn't been implemented in browsers yet.
-      img.addClass('settle');
-      img.removeClass(direction);
+      current.addClass('settle');
+      current.removeClass(direction);
     }
   };
 
@@ -1398,7 +1401,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
   };
 
   KNF.prototype.resize = function() {
-    $('#foto .images img:not([state=gone])').each(function(i, img) {
+    $('#foto .images img').each(function(i, img) {
       img = $(img);
       console.log('updating', img.attr('data-name'));
       var foto = this.fotos[this.path].children[img.attr('data-name')];

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -467,7 +467,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
 
     this.update_foto_frame(foto, direction);
 
-    this.onresize();
+    this.resize();
     $('html').addClass('noscroll');
     frame.css('display', 'flex'); // show
   };
@@ -644,7 +644,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
           next.attr('data-name', this.foto.next.name);
           next.attr('src', this.chooseFoto(this.foto.next).src);
           $('.images', frame).prepend(next);
-          this.onresize();
+          this.resize();
         }
         next.removeClass('settle'); // just in case
         next.css({
@@ -667,7 +667,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
           prev.attr('data-name', this.foto.prev.name);
           prev.attr('src', props.src);
           $('.images', frame).append(prev);
-          this.onresize();
+          this.resize();
         }
         prev.removeClass('settle'); // just in case
         prev.css({
@@ -735,7 +735,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
             next.css('transform', 'translateX(9999px)'); // off-screen
             next.attr('src', this.chooseFoto(this.foto.next).src);
             $('.images', frame).prepend(next);
-            this.onresize();
+            this.resize();
           }
         }.bind(this), SWITCH_DURATION);
 
@@ -773,7 +773,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
             prev.css('transform', 'translateX(9999px)'); // off-screen
             prev.attr('src', this.chooseFoto(this.foto.prev).src);
             $('.images', frame).append(prev);
-            this.onresize();
+            this.resize();
           }
         }.bind(this), SWITCH_DURATION);
 
@@ -906,13 +906,13 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
   KNF.prototype.open_sidebar = function() {
     this.sidebar = true;
     $('#foto').addClass('sidebar');
-    this.onresize();
+    this.resize();
   };
 
   KNF.prototype.close_sidebar = function() {
     this.sidebar = false;
     $('#foto').removeClass('sidebar');
-    this.onresize();
+    this.resize();
   };
 
   KNF.prototype.removeFoto = function() {
@@ -1012,7 +1012,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
         foto.calculate_cache_urls();
         if (foto === this.foto) {
           img.attr('src', this.chooseFoto(foto).src);
-          this.onresize();
+          this.resize();
         }
 
         foto.tags = tags;
@@ -1054,8 +1054,6 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
       devicePixelRatio = window.devicePixelRatio;
     }
 
-    this.updateMaxSize();
-
     var src = foto.large;
     var width = foto.largeSize[0];
     var height = foto.largeSize[1];
@@ -1086,6 +1084,11 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
   };
 
   KNF.prototype.onresize = function() {
+    this.updateMaxSize();
+    this.resize();
+  };
+
+  KNF.prototype.resize = function() {
     $('#foto .images img:not([state=gone])').each(function(i, img) {
       img = $(img);
       console.log('updating', img.attr('data-name'));
@@ -1224,6 +1227,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
       $('#search').val(search);
     }
 
+    this.updateMaxSize();
     this.onpopstate();
   };
 

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -389,23 +389,25 @@
     if (foto && foto.type != 'foto') {
       foto = null;
     }
+
+    // there is a photo frame - close it
+    if (this.saving_status >= 2 && !confirmed) {
+      console.warn('waiting until changes are saved');
+      // Usually changes are saved within 100ms, so wait that time and try
+      // again.
+      setTimeout(function() {
+        if (this.saving_status < 2) {
+          this.change_foto(foto);
+        } else if (confirm('Wijzigingen zijn niet opgeslagen.\nDoorgaan?')) {
+          this.change_foto(foto, true);
+        }
+      }.bind(this), 100);
+      return;
+    }
+
     if (!foto) {
       // close photo frame if there is one
       if (this.foto) {
-        // there is a photo frame - close it
-        if (this.saving_status >= 2 && !confirmed) {
-          console.warn('waiting until changes are saved');
-          // Usually changes are saved within 100ms, so wait that time and try
-          // again.
-          setTimeout(function() {
-            if (this.saving_status < 2) {
-              this.change_foto(foto);
-            } else if (confirm('Wijzigingen zijn niet opgeslagen.\nDoorgaan?')) {
-              this.change_foto(foto, true);
-            }
-          }.bind(this), 100);
-          return;
-        }
         $('#foto').hide();
         $('html').removeClass('noscroll');
         delete this.foto.newTags;
@@ -746,13 +748,15 @@
         }.bind(this), 1000);
 
         foto.thumbnailSize = data.thumbnailSize;
+        foto.thumbnail2xSize = data.thumbnail2xSize;
         foto.largeSize = data.largeSize;
+        foto.large2xSize = data.large2xSize;
 
         foto.description = description;
         foto.visibility = visibility;
 
         foto.calculate_cache_urls();
-        if (foto == this.foto) {
+        if (foto === this.foto) {
           this.update_foto_src(foto);
         }
 

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -665,6 +665,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
         prev.removeClass('settle'); // just in case
         prev.css({
           'transform': 'translateX('+Math.min(0, moved - this.maxWidth) + 'px)',
+          'opacity':   1,
         });
         current.css({
           'transform': 'scale('+Math.min(1, 1 - moved / this.maxWidth / 2)+')',

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -629,7 +629,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
 
       if (moved < 0) {
         // Preview next image
-        if ($('.image-wrapper[state=next]', frame).length == 0) {
+        if (next.length == 0) {
           next = $('<div class="image-wrapper"><img class="img"></div>');
           next.attr('data-name', this.foto.next.name);
           next.attr('state', 'next');
@@ -644,8 +644,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
           'transform': 'scale(' +Math.min(1, 1 - (this.maxWidth - -moved) / this.maxWidth / 2) + ')',
         });
         current.css({
-          'left':      moved + 'px',
-          'transform': 'scale(1)',
+          'transform': 'scale(1) translateX(' + moved + 'px)',
           'opacity':   1,
         });
       } else {
@@ -654,7 +653,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
 
       if (moved > 0) {
         // Preview previous image
-        if ($('.image-wrapper[state=prev]', frame).length == 0) {
+        if (prev.length == 0) {
           prev = $('<div class="image-wrapper"><img class="img"></div>');
           prev.attr('data-name', this.foto.prev.name);
           prev.attr('state', 'prev');
@@ -665,10 +664,9 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
         }
         prev.removeClass('settle'); // just in case
         prev.css({
-          'left':      Math.min(0, moved - this.maxWidth) + 'px',
+          'transform': 'translateX('+Math.min(0, moved - this.maxWidth) + 'px)',
         });
         current.css({
-          'left':      0,
           'transform': 'scale('+Math.min(1, 1 - moved / this.maxWidth / 2)+')',
           'opacity':   Math.min(1, 1 - moved / this.maxWidth),
         });
@@ -678,8 +676,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
 
       if (moved == 0) {
         current.css({
-          'left':      0,
-          'transform': 'scale(1)',
+          'transform': '',
           'opacity':   1,
         });
       }
@@ -706,8 +703,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
         });
 
         current.css({
-          'left':      -this.maxWidth + 'px',
-          'transform': 'scale(1)',
+          'transform': 'scale(1) translateX(' + (-this.maxWidth) + 'px)',
           'opacity':   1,
         });
         current.addClass('settle');
@@ -716,21 +712,38 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
         current.attr('state', 'prev');
         next.attr('state', 'current');
         setTimeout(function() {
-          next.removeClass('settle');
+          $('.image-wrapper[state=prev]', frame)
+            .removeClass('settle');
+          $('.image-wrapper[state=current]', frame)
+            .removeClass('settle');
+          // Create the next image (to cache)
+          // not sure whether it actually helps...
+          // TODO: code duplication
+          if (this.foto.next && this.foto.next.type != 'album' &&
+              $('.image-wrapper[state=next]', frame).length == 0) {
+            var next = $('<div class="image-wrapper"><img class="img"></div>');
+            next.attr('data-name', this.foto.next.name);
+            next.attr('state', 'next');
+            next.css('transform', 'translateX(9999px)'); // off-screen
+            $('img', next)
+              .attr('src', this.chooseFoto(this.foto.next).src);
+            $('.images', frame).prepend(next);
+            this.onresize();
+          }
         }.bind(this), SWITCH_DURATION);
 
         this.update_foto_frame(this.foto.next, 'right');
 
       } else if (moved > this.maxWidth / 6 && this.foto.prev && this.foto.prev.type != 'album') {
+        console.log('prev', prev);
         // previous image
         console.log('end: prev');
         prev.css({
-          'left': 0,
+          'transform': '',
         });
         prev.addClass('settle');
 
         current.css({
-          'left':      0,
           'transform': 'scale(0.5)',
           'opacity':   0,
         });
@@ -740,7 +753,23 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
         current.attr('state', 'next');
         prev.attr('state', 'current');
         setTimeout(function() {
-          prev.removeClass('settle');
+          $('.image-wrapper[state=current]', frame)
+            .removeClass('settle');
+          $('.image-wrapper[state=next]', frame)
+            .removeClass('settle');
+          // cache the previous image in case the user goes back one more
+          // TODO: code duplication
+          if (this.foto.prev && this.foto.prev.type != 'album' &&
+              $('.image-wrapper[state=prev]', frame).length == 0) {
+            var prev = $('<div class="image-wrapper"><img class="img"></div>');
+            prev.attr('data-name', this.foto.prev.name);
+            prev.attr('state', 'prev');
+            prev.css('transform', 'translateX(9999px)'); // off-screen
+            $('img', prev)
+              .attr('src', this.chooseFoto(this.foto.prev).src);
+            $('.images', frame).append(prev);
+            this.onresize();
+          }
         }.bind(this), SWITCH_DURATION);
 
         this.update_foto_frame(this.foto.prev, 'left');
@@ -749,7 +778,6 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
         console.log('end: current');
         // current image
         current.css({
-          'left':      0,
           'transform': 'scale(1)',
           'opacity':   1,
         });
@@ -762,7 +790,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
         next.addClass('settle');
 
         prev.css({
-          'left': -this.maxWidth-8,
+          'transform': 'translateX('+(-this.maxWidth-8)+'px)',
         });
         prev.addClass('settle');
 

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -629,7 +629,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
     // A second finger was placed on the surface
     if (e.originalEvent.touches.length == 2) {
       var prev = $('#foto .images img[state=prev]');
-      if (prev) {
+      if (prev.length) {
         // Possibly within a swype to the right. Let this image disappear to the left.
         var propsPrev = this.chooseFoto(this.foto.prev);
         prev.css('transform', 'translateX('+Math.min(0, -(this.maxWidth+propsPrev.width)/2) + 'px)')
@@ -641,7 +641,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
       }
 
       var next = $('#foto .images img[state=next]');
-      if (next) {
+      if (next.length) {
         // Possibly within a swype to the left. Fade the next image.
         next.css({
           'transform': 'scale(0.5)',

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -465,12 +465,12 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
           current.removeClass('settle');
         }.bind(this), SWITCH_DURATION);
       }
+      this.resize(current);
       $('.images', frame).append(current);
     }
 
     this.update_foto_frame(foto, direction);
 
-    this.resize();
     $('html').addClass('noscroll');
     frame.css('display', 'flex'); // show
 
@@ -819,7 +819,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
         next.attr('data-name', this.foto.next.name);
         next.attr('src', this.chooseFoto(this.foto.next).src);
         $('#foto .images').prepend(next);
-        this.resize();
+        this.resize(next);
       }
       next.removeClass('settle'); // just in case
       next.css({
@@ -842,7 +842,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
         prev.attr('data-name', this.foto.prev.name);
         prev.attr('src', props.src);
         $('#foto .images').append(prev);
-        this.resize();
+        this.resize(prev);
       }
       prev.removeClass('settle'); // just in case
       prev.css({
@@ -950,7 +950,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
           next.css('transform', 'translateX(9999px)'); // off-screen
           next.attr('src', this.chooseFoto(this.foto.next).src);
           $('#foto .images').prepend(next);
-          this.resize();
+          this.resize(next);
         }
       }.bind(this), SWITCH_DURATION);
 
@@ -987,7 +987,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
           prev.css('transform', 'translateX(-9999px)'); // off-screen
           prev.attr('src', this.chooseFoto(this.foto.prev).src);
           $('#foto .images').append(prev);
-          this.resize();
+          this.resize(prev);
         }
       }.bind(this), SWITCH_DURATION);
 
@@ -1217,12 +1217,14 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
   KNF.prototype.open_sidebar = function() {
     this.sidebar = true;
     $('#foto').addClass('sidebar');
+    this.updateMaxSize();
     this.resize();
   };
 
   KNF.prototype.close_sidebar = function() {
     this.sidebar = false;
     $('#foto').removeClass('sidebar');
+    this.updateMaxSize();
     this.resize();
   };
 
@@ -1323,7 +1325,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
         foto.calculate_cache_urls();
         if (foto === this.foto) {
           img.attr('src', this.chooseFoto(foto).src);
-          this.resize();
+          this.resize(img);
         }
 
         foto.tags = tags;
@@ -1400,8 +1402,12 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
   };
 
   KNF.prototype.resize = function() {
-    $('#foto .images img').each(function(i, img) {
-      img = $(img);
+    if (arguments.length == 0) {
+      arguments = $('#foto .images img');
+    }
+    for (var i=0; i<arguments.length; i++) {
+      var img = $(arguments[i]);
+      if (img === null) continue;
       console.log('updating', img.attr('data-name'));
       var foto = this.fotos[this.path].children[img.attr('data-name')];
       var props = this.chooseFoto(foto);
@@ -1410,11 +1416,11 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
                'left': (this.maxWidth-props.width)/2,
                'top': (this.maxHeight-props.height)/2});
       // switch to 2x if needed (but don't switch back for this photo)
-      if (props.src == this.foto.large2x &&
-          img.attr('src') != this.foto.large2x) {
+      if (props.src == foto.large2x &&
+          img.attr('src') != foto.large2x) {
         img.attr('src', props.src);
       }
-    }.bind(this));
+    }
   };
 
   KNF.prototype.onedit = function(e) {

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -385,12 +385,7 @@
   };
 
   KNF.prototype.change_foto = function(foto, confirmed) {
-    foto = foto || null;
-    if (foto && foto.type != 'foto') {
-      foto = null;
-    }
-
-    // there is a photo frame - close it
+    // check for unsaved changes
     if (this.saving_status >= 2 && !confirmed) {
       console.warn('waiting until changes are saved');
       // Usually changes are saved within 100ms, so wait that time and try
@@ -403,6 +398,11 @@
         }
       }.bind(this), 100);
       return;
+    }
+
+    foto = foto || null;
+    if (foto && foto.type != 'foto') {
+      foto = null;
     }
 
     if (!foto) {

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -69,8 +69,8 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
     this.parents = {};
     this.people = {};
     this.allpeople = [];
-    this.swype_start = null;
-    this.swype_moved = null;
+    this.swipe_start = null;
+    this.swipe_moved = null;
     this.zoom_distance = null; // pinch-zoom action
     this.zoom_center = null;   // pinch-zoom action
     this.zoom_current = null;  // pinch-zoom action
@@ -699,7 +699,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
     if (e.originalEvent.touches.length == 2) {
       var prev = $('#foto .images img[state=prev]');
       if (prev.length) {
-        // Possibly within a swype to the right. Let this image disappear to the left.
+        // Possibly within a swipe to the right. Let this image disappear to the left.
         var propsPrev = this.chooseFoto(this.foto.prev);
         prev.css('transform', 'translateX('+Math.min(0, -(this.maxWidth+propsPrev.width)/2) + 'px)')
         prev.addClass('settle');
@@ -711,7 +711,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
 
       var next = $('#foto .images img[state=next]');
       if (next.length) {
-        // Possibly within a swype to the left. Fade the next image.
+        // Possibly within a swipe to the left. Fade the next image.
         next.css({
           'transform': 'scale(0.5)',
           'opacity':   0,
@@ -764,8 +764,8 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
           scale: 1,
         };
         // assume the first finger is points[0]
-        var moved = points[0].x - this.swype_start;
-        this.swype_start = null;
+        var moved = points[0].x - this.swipe_start;
+        this.swipe_start = null;
         if (moved < 0) {
           this.zoom_previous.translateX = moved;
           console.log('extra translateX', this.zoom_previous.translateX);
@@ -775,14 +775,14 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
     } else {
       // The first finger was placed on the surface
       if (this.zoom_previous === null) {
-        this.swype_start = e.originalEvent.touches[0].clientX;
-        console.log('swype start', this.swype_start);
+        this.swipe_start = e.originalEvent.touches[0].clientX;
+        console.log('swipe start', this.swipe_start);
       }
     }
   };
 
   KNF.prototype.touchmove = function(e) {
-    if (this.swype_start === null && this.zoom_previous === null) return;
+    if (this.swipe_start === null && this.zoom_previous === null) return;
 
     e.preventDefault();
 
@@ -853,9 +853,9 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
       return;
     }
 
-    // We're within a swype action (to the left or right).
+    // We're within a swipe action (to the left or right).
 
-    var moved = (e.originalEvent.touches[0].clientX - this.swype_start);
+    var moved = (e.originalEvent.touches[0].clientX - this.swipe_start);
     if (moved > 0 && (!this.foto.prev || this.foto.prev.type === 'album')) {
       // first photo
       moved = 0;
@@ -865,7 +865,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
       moved = 0;
     }
 
-    this.swype_moved = moved;
+    this.swipe_moved = moved;
 
     var current = $('#foto .images img[state=current]');
     var prev = $('#foto .images img[state=prev]'); // possibly 0
@@ -959,14 +959,14 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
     }
 
     // We haven't moved yet - it's just a tap?
-    if (this.swype_moved === null) return;
+    if (this.swipe_moved === null) return;
 
-    // The swype action has ended. See whether we should switch the image or
+    // The swipe action has ended. See whether we should switch the image or
     // just jump back to the current.
 
-    var moved = this.swype_moved;
-    this.swype_start = null;
-    this.swype_moved = null;
+    var moved = this.swipe_moved;
+    this.swipe_start = null;
+    this.swipe_moved = null;
 
     var current = $('#foto .images img[state=current]').last();
     var next = $('#foto .images img[state=next]'); // possibly 0
@@ -974,7 +974,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
 
     if (moved < this.maxWidth / -16 && this.foto.next && this.foto.next.type != 'album') {
       // next image
-      console.log('end of swype: next image');
+      console.log('end of swipe: next image');
       next.addClass('settle');
       next.css({
         'transform': '',
@@ -1015,7 +1015,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
 
     } else if (moved > this.maxWidth / 16 && this.foto.prev && this.foto.prev.type != 'album') {
       // previous image
-      console.log('end of swype: previous image');
+      console.log('end of swipe: previous image');
       prev.css({
         'transform': '',
       });
@@ -1052,7 +1052,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
 
     } else {
       // current image
-      console.log('end of swype: current image');
+      console.log('end of swipe: current image');
       current.css({
         'transform': '',
         'opacity':   1,
@@ -1110,7 +1110,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
   // Fixes things like the image shooting off the side or zooming with scale < 0
   KNF.prototype.fix_zoom_end = function(centerX, centerY) {
     if (this.zoom_previous.scale <= 1) {
-      // Zoomed out - exit zoom/pan session (to enable back/forward swype)
+      // Zoomed out - exit zoom/pan session (to enable back/forward swipe)
       this.zoom_previous = null;
       return true;
     }

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -661,16 +661,17 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
 
       if (moved > 0) {
         // Preview previous image
+        var props = this.chooseFoto(this.foto.prev);
         if (prev.length == 0) {
           prev = $('<img class="img" state="prev"/>');
           prev.attr('data-name', this.foto.prev.name);
-          prev.attr('src', this.chooseFoto(this.foto.prev).src);
+          prev.attr('src', props.src);
           $('.images', frame).append(prev);
           this.onresize();
         }
         prev.removeClass('settle'); // just in case
         prev.css({
-          'transform': 'translateX('+Math.min(0, moved - this.maxWidth) + 'px)',
+          'transform': 'translateX('+Math.min(0, moved - (this.maxWidth+props.width)/2) + 'px)',
           'opacity':   1,
         });
         current.css({

--- a/kn/fotos/media/fotos.js
+++ b/kn/fotos/media/fotos.js
@@ -537,12 +537,12 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
   KNF.prototype.init_foto_frame = function() {
     var frame = $('#foto');
     $('.close', frame)
-        .click(function() {
+        .on('touchstart', function() {
           this.change_foto(null);
           return false;
         }.bind(this));
     $('.open-sidebar', frame)
-        .click(function() {
+        .on('touchstart', function(e) {
           if (this.sidebar) {
             this.close_sidebar();
           } else {
@@ -605,12 +605,24 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
     frame.mousemove(showhide.bind(this));
     frame.on('touchstart', showhide.bind(this));
 
-    frame.on('touchstart', function(e) {
+    frame.on('touchstart', touchstart.bind(this));
+    function touchstart(e) {
+      if (this.sidebar) return;
       this.swype_start = e.originalEvent.touches[0].clientX;
       console.log('start', this.swype_start);
-    }.bind(this));
+    }
 
-    frame.on('touchmove', function(e) {
+    frame.on('touchmove', touchmove.bind(this));
+    function touchmove(e) {
+      if (this.sidebar) return;
+      if (this.swype_start === null) return;
+      if (e.originalEvent.touches.length > 1) {
+        // pinch-zoom
+        touchend();
+        return;
+      }
+      e.preventDefault();
+
       var moved = (e.originalEvent.touches[0].clientX - this.swype_start);
       if (moved > 0 && (!this.foto.prev || this.foto.prev.type === 'album')) {
         // first photo
@@ -681,9 +693,10 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
           'opacity':   1,
         });
       }
-    }.bind(this));
+    }
 
-    frame.on('touchend', function(e) {
+    frame.on('touchend', touchend.bind(this));
+    function touchend(e) {
       if (this.swype_moved === null) return;
 
       var moved = this.swype_moved;
@@ -801,7 +814,7 @@ var SWITCH_DURATION = 200; // 200ms, keep up to date with fotos.css
           prev.removeClass('settle');
         }.bind(this), SWITCH_DURATION);
       }
-    }.bind(this));
+    }
   };
 
   KNF.prototype.update_foto_tags = function(sidebar) {

--- a/kn/fotos/templates/fotos/fotos.html
+++ b/kn/fotos/templates/fotos/fotos.html
@@ -87,13 +87,10 @@ dit album zien.{% endblocktrans %}</p>
 {% else %}
 <ul id="fotos"></ul>
 {% endif %}
-<div id="foto"></div>
-<div class="template foto-frame">
-  <div class="image-wrapper">
-    <img class="img"/>
-    <a class="nav prev"><img src="{{ MEDIA_URL }}fotos/prev.svg" alt="{% trans "Vorige" %}" title="{% trans "Vorige" %}"/></a>
-    <a class="nav next"><img src="{{ MEDIA_URL }}fotos/next.svg" alt="{% trans "Volgende" %}" title="{% trans "Volgende" %}"/></a>
-  </div>
+<div id="foto">
+  <div class="images"></div>
+  <a class="nav prev"><img src="{{ MEDIA_URL }}fotos/prev.svg" alt="{% trans "Vorige" %}" title="{% trans "Vorige" %}"/></a>
+  <a class="nav next"><img src="{{ MEDIA_URL }}fotos/next.svg" alt="{% trans "Volgende" %}" title="{% trans "Volgende" %}"/></a>
   <a class="nav close" href><img src="{{ MEDIA_URL }}fotos/close.svg" alt="{% trans "Sluiten" %}" title="{% trans "Sluiten" %}"/></a>
   <a class="nav open-sidebar" href><img src="{{ MEDIA_URL }}fotos/sidebar.svg" alt="{% trans "Tags" %}" title="{% trans "Tags" %}"/></a>
   <div class="sidebar">

--- a/kn/fotos/templates/fotos/fotos.html
+++ b/kn/fotos/templates/fotos/fotos.html
@@ -10,7 +10,7 @@
 <script type="text/javascript"
         src="{{ MEDIA_URL }}base/jquery-ui-1.8.22/the.js" defer></script>
 {% endif %}
-<script type="text/javascript" src="{{ MEDIA_URL }}fotos/fotos.js?v=3"></script>
+<script type="text/javascript" src="{{ MEDIA_URL }}fotos/fotos.js?v=4"></script>
 <script type="text/javascript">
 'use strict';
 expandHeader = false;
@@ -42,7 +42,7 @@ if ('srcset' in (new Image())) {
 {% block styles %}
 {{ block.super }}
 <link rel="stylesheet" type="text/css"
-        href="{{ MEDIA_URL }}fotos/fotos.css?v=3" />
+        href="{{ MEDIA_URL }}fotos/fotos.css?v=4" />
 {% if fotos_admin %}
 <link rel="stylesheet" type="text/css"
     deferred-href="{{ MEDIA_URL }}base/jquery-ui-1.8.22/the.css"/>

--- a/kn/fotos/templates/fotos/fotos.html
+++ b/kn/fotos/templates/fotos/fotos.html
@@ -134,7 +134,6 @@ dit album zien.{% endblocktrans %}</p>
       <a class="orig">{% trans "origineel" %}</a>
     </div>
   </div>
-  <link rel="prefetch" as="image" class="prefetch-image"/>
 </div>
 <div id="fotos-footer">
   <a class="download" href="?download">{% trans "Download dit fotoalbum" %}</a>


### PR DESCRIPTION
Maak switchen tussen foto's een stuk mooier. Het idee voor de fadein/fadeout (bij de buttons/pijltjestoetsen) heb ik gejat van OneDrive. Verder heb ik ook swype voor touchscreens toegevoegd (getest op Chrome en Firefox op Android - Safari moet nog).

![screenshot_20170716-034231](https://user-images.githubusercontent.com/729697/28243834-f9dcf35a-69d8-11e7-8aa9-1ab9a3d3aaa6.png)


Getest in IE11 (behalve swype want het was een VM en geen mobieltje). Overigens wil ik hiermee ook support droppen voor alles <IE11, aangezien die browsers vrijwel niet meer gebruikt worden.