### PR TITLE
shell: automatically generate a brand name in create_brand

### DIFF
--- a/utils/shell.py
+++ b/utils/shell.py
@@ -103,10 +103,10 @@ def create_study(name):
                            'humanNames': [{'human': name}]})
 
 
-def create_brand(suffix, name):
-    Es.ecol.insert({'humanNames': [{'human': name}],
-                    'names': [],
-                    'sofa_suffix': suffix,
+def create_brand(name, humanName):
+    Es.ecol.insert({'humanNames': [{'human': humanName}],
+                    'names': ['!brand-'+name],
+                    'sofa_suffix': name,
                     'tags': [Es.id_by_name('!sofa-brand')],
                     'types': ['brand']})
 


### PR DESCRIPTION
Bij het testen van brands voor de entities pagina merkte ik dat de name (`!brand-voorzitter` etc.) niet ingevuld werd. Leek me wel handig.