### PR TITLE
Oude planning bekijken

### DIFF
--- a/kn/planning/entities.py
+++ b/kn/planning/entities.py
@@ -57,11 +57,14 @@ class Event(SONWrapper):
 
     @classmethod
     def all_in_future(cls):
-        return cls.all_since_datetime(now())
+        return cls.all_in_period(now(), None)
 
     @classmethod
-    def all_since_datetime(cls, since):
-        for c in ecol.find({'date': {'$gte': since}}):
+    def all_in_period(cls, start, end):
+        query = {'$gte': start, '$lte': end}
+        if end is None:
+            query = {'$gte': start}
+        for c in ecol.find({'date': query}):
             yield cls.from_data(c)
 
     @classmethod

--- a/kn/planning/templates/planning/overview.html
+++ b/kn/planning/templates/planning/overview.html
@@ -17,10 +17,21 @@
     vertical-align: top;
     text-align: center;
 }
+#planning-toolbar {
+    text-align: right;
+}
+#planning-toolbar a.current {
+    font-weight: bold;
+}
 </style>
 {% endblock styles %}
 
 {% block body %}
+<div id="planning-toolbar">
+    <a href="?year=now" {% if period == "now" %} class="current"{% endif %}>huidige planning</a> |
+    <a href="?year=past1" {% if period == "past1" %} class="current"{% endif %}>afgelopen jaar</a> |
+    <a href="?year=past2" {% if period == "past2" %} class="current"{% endif %}>jaar daarvoor</a>
+</div>
 <div id="planning-overview-wrapper">
     <table id="planning-overview">
         <tr>

--- a/kn/planning/templates/planning/overview.html
+++ b/kn/planning/templates/planning/overview.html
@@ -6,14 +6,14 @@
 {% block styles %}
 {{ block.super }}
 <style type="text/css">
-#planningOverview-wrapper {
+#planning-overview-wrapper {
     overflow-x: auto;
 }
-#planningOverview {
+#planning-overview {
     width: 100%;
     box-sizing: border-box;
 }
-#planningOverview td {
+#planning-overview td {
     vertical-align: top;
     text-align: center;
 }
@@ -21,8 +21,8 @@
 {% endblock styles %}
 
 {% block body %}
-<div id="planningOverview-wrapper">
-    <table id="planningOverview">
+<div id="planning-overview-wrapper">
+    <table id="planning-overview">
         <tr>
 {% for pool in pools %}
             {# TODO pool niet tonen als er voor geen enkel te tonen event diensten zijn #}
@@ -33,8 +33,7 @@
         <tr>
             {# TODO move into stylesheet #}
             <td
-                colspan="{{ pools|length }}"
-                class="poolHeader">
+                colspan="{{ pools|length }}">
                 {% if may_manage_planning %}
                 <a href="{% url "planning-event-edit" eventid=event.id %}">
                     <strong>{{ event.datetime|date:"l j F Y" }}</strong>

--- a/kn/planning/views.py
+++ b/kn/planning/views.py
@@ -99,18 +99,28 @@ templates = {
 
 @login_required
 def planning_view(request):
-    if 'lookbehind' in request.GET:
-        lookbehind = int(request.GET['lookbehind'])
-    else:
-        lookbehind = 1
+    period = 'now'
+    if request.GET.get('year') in {'past1', 'past2'}:
+        period = request.GET['year']
     pools = list(Pool.all())
     poolid2index = dict()
     poolids = set()
     for pool in pools:
         poolids.add(_id(pool))
     # TODO reduce number of queries
-    event_entities = list(Event.all_since_datetime(
-        date_to_midnight(now()) - datetime.timedelta(days=lookbehind)))
+    current = date_to_midnight(now() - datetime.timedelta(days=1))
+    past1year = date_to_midnight(now() - datetime.timedelta(days=356))
+    past2year = date_to_midnight(now() - datetime.timedelta(days=356*2))
+    if period == 'now':
+        start = current
+        end = None
+    elif period == 'past1':
+        start = past1year
+        end = current
+    elif period == 'past2':
+        start = past2year
+        end = past1year
+    event_entities = list(Event.all_in_period(start, end))
     used_pools = set()
     for e in event_entities:
         for v in e.vacancies():
@@ -145,7 +155,8 @@ def planning_view(request):
     events.sort(key=lambda x: x['datetime'])
     return render_to_response('planning/overview.html',
                               {'events': events,
-                               'pools': pools_tpl},
+                               'pools': pools_tpl,
+                               'period': period},
                               context_instance=RequestContext(request))
 
 


### PR DESCRIPTION
Zoals gevraagd in #434 (@awesterb). Het was al mogelijk om het verleden te bekijken (73a847b1ad585c0b3e7e9395d4bcc45105eac8bb), maar dit maakt het een zichtbare en makkelijk bruikbare optie.
Als iemand een betere suggestie heeft voor de waarde van de parameter (`past1` en `past2`) dan is dat welkom.

Ik heb gekeken in de logs van Piwik en het afgelopen jaar heeft niemand `?lookbehind=` gebruikt (die Piwik niet geblokkeerd had via een adblocker).

fixes #434