### PR TITLE
Systemd ready notification

### DIFF
--- a/bin/cilia
+++ b/bin/cilia
@@ -2,4 +2,4 @@
 
 PYTHON="${PYTHON:-python}"
 
-$PYTHON /root/kninfra/utils/cilia.py
+exec $PYTHON /root/kninfra/utils/cilia.py

--- a/bin/cilia-tunnel
+++ b/bin/cilia-tunnel
@@ -5,6 +5,6 @@
 cd /var/run/infra
 
 rm -f S-cilia
-socat UNIX-LISTEN:S-cilia,fork,mode=660,group=infra \
+exec socat UNIX-LISTEN:S-cilia,fork,mode=660,group=infra \
             EXEC:"ssh root@phassa \
                 'socat STDIO UNIX-CONNECT:/var/run/infra/S-cilia'"

--- a/bin/daan
+++ b/bin/daan
@@ -2,4 +2,4 @@
 
 PYTHON="${PYTHON:-python}"
 
-$PYTHON /root/kninfra/utils/daan.py
+exec $PYTHON /root/kninfra/utils/daan.py

--- a/bin/giedo
+++ b/bin/giedo
@@ -2,4 +2,4 @@
 
 PYTHON="${PYTHON:-python}"
 
-$PYTHON /home/infra/repo/utils/giedo.py
+exec $PYTHON /home/infra/repo/utils/giedo.py

--- a/bin/giedo-sync
+++ b/bin/giedo-sync
@@ -3,4 +3,4 @@
 PYTHON="${PYTHON:-python}"
 
 echo '{"type":"sync"}' \
-    | $PYTHON $HOME/repo/bin/whim-client /var/run/infra/S-giedo
+    | exec $PYTHON $HOME/repo/bin/whim-client /var/run/infra/S-giedo

--- a/bin/hans
+++ b/bin/hans
@@ -2,4 +2,4 @@
 
 PYTHON="${PYTHON:-python}"
 
-$PYTHON /home/infra/repo/utils/hans.py
+exec $PYTHON /home/infra/repo/utils/hans.py

--- a/bin/moniek
+++ b/bin/moniek
@@ -2,4 +2,4 @@
 
 PYTHON="${PYTHON:-python}"
 
-$PYTHON /home/sys-moniek/kninfra/utils/moniek.py
+exec $PYTHON /home/sys-moniek/kninfra/utils/moniek.py

--- a/bin/moniek-tunnel
+++ b/bin/moniek-tunnel
@@ -5,6 +5,6 @@
 cd /var/run/infra
 
 rm -f S-moniek
-socat UNIX-LISTEN:S-moniek,fork,mode=660,group=infra \
+exec socat UNIX-LISTEN:S-moniek,fork,mode=660,group=infra \
             EXEC:"ssh root@phassa \
                 'socat STDIO UNIX-CONNECT:/var/run/infra/S-moniek'"

--- a/bin/whim-client
+++ b/bin/whim-client
@@ -4,6 +4,9 @@ import _import
 
 import sys
 import json
+import time
+import os.path
+import logging
 
 from kn.utils.whim import WhimClient
 
@@ -16,10 +19,18 @@ def main():
         msg = sys.argv[2]
     else:
         msg = sys.stdin.read()
-    wc = WhimClient(sys.argv[1])
+    fn = sys.argv[1]
+    if not os.path.exists(fn):
+        logging.warn("%s: does not exist.  Waiting a bit.", fn)
+        time.sleep(1)
+    if not os.path.exists(fn):
+        logging.error("%s: still doesn't exist.", fn)
+        return 1
+    wc = WhimClient(fn)
     print(json.dumps(wc.send(json.loads(msg))))
     return 0
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     sys.exit(main())

--- a/kn/utils/cilia/__init__.py
+++ b/kn/utils/cilia/__init__.py
@@ -26,6 +26,7 @@ class Cilia(WhimDaemon):
         super(Cilia, self).pre_mainloop()
         if hasattr(settings, 'INFRA_UID'):
             os.chown(settings.CILIA_SOCKET, settings.INFRA_UID, -1)
+        self.notify_systemd()
 
     def handle(self, d):
         if d['type'] == 'unix':

--- a/kn/utils/daan/__init__.py
+++ b/kn/utils/daan/__init__.py
@@ -30,6 +30,7 @@ class Daan(WhimDaemon):
     def pre_mainloop(self):
         super(Daan, self).pre_mainloop()
         os.chown(settings.DAAN_SOCKET, settings.INFRA_UID, -1)
+        self.notify_systemd()
 
     def handle(self, d):
         if d['type'] == 'postfix':

--- a/kn/utils/giedo/__init__.py
+++ b/kn/utils/giedo/__init__.py
@@ -62,6 +62,10 @@ class Giedo(WhimDaemon):
             ('wolk', self.cilia, self._gen_wolk),
             ('quassel', self.daan, self._gen_quassel))
 
+    def pre_mainloop(self):
+        super(Giedo, self).pre_mainloop()
+        self.notify_systemd()
+
     def _gen_quassel(self):
         return {'type': 'quassel',
                 'changes': generate_quassel_changes(self)}

--- a/kn/utils/hans/__init__.py
+++ b/kn/utils/hans/__init__.py
@@ -19,6 +19,10 @@ class Hans(WhimDaemon):
         super(Hans, self).__init__(settings.HANS_SOCKET)
         self.mailman_lock = threading.Lock()
 
+    def pre_mainloop(self):
+        super(Hans, self).pre_mainloop()
+        self.notify_systemd()
+
     def handle(self, d):
         if d['type'] == 'maillist-get-membership':
             return maillist_get_membership(self)

--- a/kn/utils/moniek/__init__.py
+++ b/kn/utils/moniek/__init__.py
@@ -24,6 +24,10 @@ class Moniek(WhimDaemon):
         for year in self.settings['years']:
             self.gcf_by_year(year)
 
+    def pre_mainloop(self):
+        super(Moniek, self).pre_mainloop()
+        self.notify_systemd()
+
     def handle(self, d):
         if d['type'] == 'fin-get-account':
             return fin.get_account(

--- a/kn/utils/whim.py
+++ b/kn/utils/whim.py
@@ -9,6 +9,7 @@ import threading
 import mirte
 import msgpack
 
+import sdnotify
 
 """ Whim is a very simple server/client protocol.
 
@@ -139,6 +140,7 @@ class WhimDaemon(object):
         self.sock_state = dict()
         self.ls = None
         self.packer = msgpack.Packer(use_bin_type=True)
+        self.systemd_notify = sdnotify.SystemdNotifier()
 
     def pre_mainloop(self):
         pass
@@ -159,6 +161,7 @@ class WhimDaemon(object):
             os.chmod(self.address, 0o600)
         self.pre_mainloop()
         ls.listen(8)
+        self.systemd_notify.notify("READY=1")
         while True:
             rs, ws, xs = select.select(list(self.sockets) + [ls],
                                        [], [])

--- a/salt/states/phassa/cilia.service
+++ b/salt/states/phassa/cilia.service
@@ -4,6 +4,7 @@ Description=Cilia applies changes on phassa thought up by Giedo
 [Service]
 ExecStart=/root/bin/cilia
 EnvironmentFile=-/etc/default/cilia
+Type=notify
 
 [Install]
 WantedBy=multi-user.target

--- a/salt/states/phassa/moniek.service
+++ b/salt/states/phassa/moniek.service
@@ -5,6 +5,7 @@ Description=moniek manages the financial accounts for giedo
 ExecStart=/home/sys-moniek/bin/moniek
 EnvironmentFile=-/etc/default/moniek
 User=sys-moniek
+Type=notify
 
 [Install]
 WantedBy=multi-user.target

--- a/salt/states/phassa/moniek.sls
+++ b/salt/states/phassa/moniek.sls
@@ -16,7 +16,7 @@ moniek packages:
             {% endif %}
 
 # pip packages
-{% for pkg in ['mirte', 'sarah', 'GitPython'] %}
+{% for pkg in ['mirte', 'sarah', 'GitPython', 'sdnotify'] %}
 {{ pkg }}:
 {% if pillar['python3'] %}
     pip.installed:

--- a/salt/states/phassa/moniek.sls
+++ b/salt/states/phassa/moniek.sls
@@ -16,7 +16,7 @@ moniek packages:
             {% endif %}
 
 # pip packages
-{% for pkg in ['mirte', 'sarah', 'GitPython', 'pymysql'] %}
+{% for pkg in ['mirte', 'sarah', 'GitPython'] %}
 {{ pkg }}:
 {% if pillar['python3'] %}
     pip.installed:

--- a/salt/states/sankhara/daan.service
+++ b/salt/states/sankhara/daan.service
@@ -4,3 +4,4 @@ Description=Daan applies changes on phassa thought up by Giedo
 [Service]
 ExecStart=/root/bin/daan
 EnvironmentFile=-/etc/default/daan
+Type=notify

--- a/salt/states/sankhara/giedo.service
+++ b/salt/states/sankhara/giedo.service
@@ -6,3 +6,4 @@ Requires=daan.service cilia-tunnel.service moniek-tunnel.service hans.service
 ExecStart=/home/infra/bin/giedo
 EnvironmentFile=-/etc/default/giedo
 User=infra
+Type=notify

--- a/salt/states/sankhara/hans.service
+++ b/salt/states/sankhara/hans.service
@@ -5,3 +5,4 @@ Description=Hans handles Mailman for Giedo
 ExecStart=/home/infra/bin/hans
 EnvironmentFile=-/etc/default/hans
 User=infra
+Type=notify

--- a/salt/states/sankhara/kninfra.sls
+++ b/salt/states/sankhara/kninfra.sls
@@ -44,7 +44,7 @@ kninfra packages:
             - imagemagick
 
 # pip packages
-{% for pkg in ['mirte', 'sarah', 'uwsgi', 'tarjan', 'reserved', 'pymysql', 'iso8601', 'google-api-python-client', 'zipseeker'] %}
+{% for pkg in ['mirte', 'sarah', 'uwsgi', 'tarjan', 'reserved', 'pymysql', 'iso8601', 'google-api-python-client', 'zipseeker', 'sdnotify'] %}
 {{ pkg }}:
 {% if pillar['python3'] %}
     pip.installed:


### PR DESCRIPTION
Uit [systemd documentatie](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=):
```
In this mode, if the process offers functionality to other processes on the system,
its communication channels should be installed before the daemon is started up
(e.g. sockets set up by systemd, via socket activation), as systemd will immediately
proceed starting follow-up units.
```
Dit is niet het geval bij onze processen, dus verander ik het type naar `notify`. Systemd wacht met starten van de dependencies tot het proces daadwerkelijk luistert.

Voorbeeld dat nu kan: `systemctl start giedo && giedo-sync`
