### PR TITLE
Add translations to robots.txt

### DIFF
--- a/kn/static/templates/static/robots.txt
+++ b/kn/static/templates/static/robots.txt
@@ -1,8 +1,13 @@
 User-agent: *
-Disallow: {{ MEDIA_URL }}base/common.js
 Disallow: /fotos/
+Disallow: /en/photos/
+Disallow: /nl/photos/
 Disallow: /foto/
+Disallow: /en/foto/
+Disallow: /nl/foto/
 Disallow: /~bas/
 Disallow: /mailman/archives/
 Disallow: /groups/leden/aktas/
+Disallow: /en/groups/leden/aktas/
+Disallow: /nl/groups/leden/aktas/
 Disallow: /kndjango.fcgi/


### PR DESCRIPTION
Otherwise some URLs will still be indexed by search engines.

Ik heb heb common.js verwijderd omdat ik geen reden zie waarom die niet geindexeerd mag worden.