### PR TITLE
[WIP] Add types

### DIFF
--- a/kn/base/conf.py
+++ b/kn/base/conf.py
@@ -1,6 +1,7 @@
 from django.conf import settings
+from datetime import datetime
 
-DT_MIN = settings.DT_MIN
-DT_MAX = settings.DT_MAX
+DT_MIN: datetime = settings.DT_MIN
+DT_MAX: datetime = settings.DT_MAX
 
 # vim: et:sta:bs=2:sw=4:

--- a/kn/fotos/entities.py
+++ b/kn/fotos/entities.py
@@ -6,6 +6,7 @@ import os.path
 import random
 import re
 import subprocess
+import typing
 from collections import namedtuple
 
 import PIL.Image
@@ -102,6 +103,7 @@ def actual_visibility(visibility):
 
 
 class FotoEntity(SONWrapper):
+    CACHES:typing.Dict[str, cache_tuple]
     CACHES = {}
 
     def __init__(self, data):

--- a/kn/leden/api.py
+++ b/kn/leden/api.py
@@ -74,7 +74,7 @@ def delete_note(data, request):
         ( << {ok: false, error: "Note not found"} ) """
     if 'secretariaat' not in request.user.cached_groups_names:
         return {'ok': False, 'error': 'Permission denied'}
-    note = Es.note_by_id(_id(data.get('id')))
+    note = Es.Note.by_id(_id(data.get('id')))
     if note is None:
         return {'ok': False, 'error': 'Note not found'}
     note.delete()

--- a/kn/leden/date.py
+++ b/kn/leden/date.py
@@ -1,15 +1,15 @@
 import datetime
 
 
-def now():
+def now() -> datetime.datetime:
     return datetime.datetime.now()
 
 
-def date_to_dt(d):
+def date_to_dt(d: datetime.date) -> datetime.datetime:
     return datetime.datetime.combine(d, datetime.time())
 
 
-def date_to_midnight(d):
+def date_to_midnight(d: datetime.date) -> datetime.datetime:
     return datetime.datetime(d.year, d.month, d.day)
 
 # vim: et:sta:bs=2:sw=4:

--- a/kn/leden/mongo.py
+++ b/kn/leden/mongo.py
@@ -2,6 +2,8 @@ import pymongo
 
 from django.conf import settings
 from django.utils import six
+import typing
+from typing import Optional, TypeVar, Any, Union, Mapping
 
 try:
     from pymongo.objectid import ObjectId
@@ -17,19 +19,21 @@ class RaceCondition(Exception):
     pass
 
 
-def _id(obj):
+def _id(obj: typing.Union[ObjectId, str, typing.Any]) -> ObjectId:
     if isinstance(obj, ObjectId):
         return obj
-    if isinstance(obj, six.string_types):
+    if isinstance(obj, str):
         return ObjectId(obj)
-    if hasattr(obj, '_id'):
+    elif isinstance(obj, six.string_types):
+        return ObjectId(obj)
+    elif hasattr(obj, '_id'):
         return obj._id
     raise ValueError("Don't know how to turn {!r} into an _id".format(obj))
 
 
 class SONWrapper(object):
 
-    def __init__(self, data, collection, parent=None, detect_race=False):
+    def __init__(self, data: Mapping[str, Any], collection: Any, parent: Optional["SONWrapper"]=None, detect_race: bool=False) -> None:
         '''
             parent:      SONWrapper can be nested. This is the parent.
             detect_race: Add a _version field which is incremented with each
@@ -40,15 +44,16 @@ class SONWrapper(object):
         self._parent = parent
         self._detect_race = detect_race
 
-    def delete(self):
+    def delete(self) -> None:
         assert self._data['_id'] is not None
         # TODO check version
+        # XXX: remove is deprecated
         self._collection.remove({
             '_id': self._data['_id']})
     # We take the keyword argument update_fields to be compatible with
     # Django's Model.save.  However, we do not use it, yet.
 
-    def save(self, update_fields=NotImplemented):
+    def save(self, update_fields: None=NotImplemented) -> None:
         if self._parent is None:
             if '_id' in self._data:
                 if self._detect_race:
@@ -73,33 +78,33 @@ class SONWrapper(object):
             self._parent.save()
 
     @property
-    def _id(self):
+    def _id(self) -> ObjectId:
         if self._parent is None:
             return self._data['_id']
         return self._parent._id
 
     @property
-    def _version(self):
+    def _version(self) -> int:
         if self._parent is None:
-            return self._data['_version']
-        return self._parent._version
+            return int(self._data['_version'])
+        return int(self._parent._version)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<SONWrapper for %s>" % self._id
 
-
-def son_property(path, default=None):
+T = typing.TypeVar('T')
+def son_property(path: typing.Sequence[str], default: Optional[T]=None) -> property:
     """ A convenience shortcut to create properties on SONWrapper
         subclasses.  Will return a getter/setter property that
         gets/sets self._data[path[0]]...[path[-1]] verbatim. """
 
-    def __getter(self):
+    def __getter(self: SONWrapper) -> Optional[T]:
         obj = self._data
         for bit in path[:-1]:
             obj = obj.get(bit, {})
         return obj.get(path[-1], default)
 
-    def __setter(self, x):
+    def __setter(self: SONWrapper, x: T) -> None:
         obj = self._data
         for bit in path[:-1]:
             if bit not in obj:

--- a/kn/leden/views.py
+++ b/kn/leden/views.py
@@ -38,14 +38,14 @@ logger = logging.getLogger(__name__)
 
 @login_required
 def user_list(request, page):
-    pr = Paginator(Es.ecol.find({'types': 'user'}).sort(
+    pr = Paginator(Es.User.all().sort(
         'humanNames.human', 1), 20)
     try:
         p = pr.page(1 if page is None else page)
     except EmptyPage:
         raise Http404
     return render(request, 'leden/user_list.html',
-                  {'users': [Es.User(m) for m in p.object_list],
+                  {'users': p.object_list,
                    'page_obj': p, 'paginator': pr})
 
 
@@ -178,7 +178,7 @@ def _user_detail(request, user):
 
 def _group_detail(request, group):
     ctx = _entity_detail(request, group)
-    isFreeToJoin = group.has_tag(Es.id_by_name('!free-to-join', True))
+    isFreeToJoin = group.has_tag_name('!free-to-join')
     rel_id = None
     if isFreeToJoin:
         dt = now()
@@ -187,7 +187,7 @@ def _group_detail(request, group):
         assert len(rel) <= 1
         for r in rel:
             rel_id = r['_id']
-    ctx.update({'isFreeToJoin': group.has_tag(Es.by_name('!free-to-join')),
+    ctx.update({'isFreeToJoin': isFreeToJoin,
                 'request': request,
                 'relation_with_group': rel_id})
     return render(request, 'leden/group_detail.html', ctx)
@@ -269,7 +269,7 @@ def years_of_birth(request):
 
 @login_required
 def users_underage(request):
-    users = Es.users()
+    users = Es.User.all()
     users = filter(lambda u: u.is_active, users)
     users = filter(lambda u: u.is_underage, users)
     users = sorted(users, key=lambda x: x.dateOfBirth)
@@ -467,7 +467,7 @@ def secr_notes(request):
     if 'secretariaat' not in request.user.cached_groups_names:
         raise PermissionDenied
     return render(request, 'leden/secr_notes.html',
-                  {'notes': Es.get_notes()})
+                  {'notes': Es.Note.all()})
 
 
 @login_required

--- a/kn/utils/giedo/db.py
+++ b/kn/utils/giedo/db.py
@@ -189,7 +189,7 @@ def update_db(giedo):
     # Set is_active on Users if and only if they are not in the `leden' group.
     # TODO We might optimize this by including it in a more generic process
     active_users = [rel['who'] for rel in Es.by_name('leden').get_rrelated(
-        None, dt_now, dt_now, False, False, False)]
+        None, dt_now, dt_now, deref=set())]
     for u in Es.users():
         is_active = u._id in active_users
         if u.is_active == is_active:

--- a/utils/leden/quarterlyMembership.py
+++ b/utils/leden/quarterlyMembership.py
@@ -21,8 +21,7 @@ def main():
     for q in range(1, max_q + 1):
         start, end = Es.quarter_to_range(q)
         for m in leden.get_rrelated(_from=start, until=end, how=None,
-                                    deref_who=False, deref_with=False,
-                                    deref_how=False):
+                                    deref=set()):
             lut[id2name[m['who']]].add(q)
     for i, name in enumerate(sorted(six.itervalues(id2name))):
         if i % 20 == 0:


### PR DESCRIPTION
This PR will add types to places it is relevant.
Mostly the database layer. If we don't have schemas in the DB, this is the best we can do for now. It also eliminates direct DB access in other places.

Advantages:
- more information for people using the database
- typechecking finds potential problems like
```
kn/leden/entities.py:538: error: Item "None" of "Union[Group, User, Study, Institute, Tag, Brand, Entity, None]" has no attribute "has_tag_name"
```
- We can use this for other stuff (automatic API generation, for example)

Disadvantages:
- some extra work when you touch the db layer
- code not fully typechecked yet, django version is too old
- requires python 3.5-3.6. Mailman released 3.2, so we can update.