### PR TITLE
leden: add email settings to smoelenboek

### DIFF
--- a/kn/leden/entities.py
+++ b/kn/leden/entities.py
@@ -1173,6 +1173,21 @@ class User(Entity):
                     {'name': self.name})
         return ('user-by-id', (), {'_id': self.id})
 
+    @property
+    def email_from_addresses(self):
+        '''
+        Return all the email adresses from which this user can send email.
+        '''
+        names = set(self.names)
+        for group in self.cached_groups:
+            if group.got_mailman_list:
+                # Not allowed to send mail from a mailing list.
+                continue
+            # The remaining groups are roles inside a group, for example
+            # "bestuur-secretaris" and "secretaris".
+            names.update(group.names)
+        return sorted(map(lambda n: '%s@%s' % (n, settings.MAILDOMAIN), names))
+
     def set_password(self, pwd, save=True):
         self._data['password'] = make_password(pwd)
         if save:

--- a/kn/leden/templates/leden/home.html
+++ b/kn/leden/templates/leden/home.html
@@ -53,7 +53,8 @@ op deze website en daar buiten:{% endblocktrans %}</p>
 <ul>
     <li><a href="{% url "chpasswd" %}">{% trans "Verander je wachtwoord" %}</a></li>
     <li><a href="{% url "ik-settings" %}">{% trans "Instellingen" %}</a></li>
-    <li><a href="{% url "balans" %}">{% trans "Bekijk je balans." %}</a></li>
+    <li><a href="{% url "balans" %}">{% trans "Bekijk je balans" %}</a></li>
+    <li><a href="{% url "ik-smtp" %}">{% trans "Stel Karpe Noktem email in." %}</a></li>
 </ul>
 
 {% endblock %}

--- a/kn/leden/urls.py
+++ b/kn/leden/urls.py
@@ -56,6 +56,7 @@ urlpatterns = [
     url(_(r'^ik/wachtwoord$'), views.ik_chpasswd, name="chpasswd"),
     url(_(r'^ik/settings$'), views.ik_settings, name="ik-settings"),
     url(_(r'^ik/smoel$'), views.ik_chsmoel, name="ik-chsmoel"),
+    url(_(r'^ik/smtp$'), views.ik_smtp, name="ik-smtp"),
     url(_(r'^api/?$'), api.view, name='leden-api'),
     url(_(r'^secretariaat/inschrijven$'),
         views.secr_add_user, name='secr-add-user'),

--- a/kn/leden/views.py
+++ b/kn/leden/views.py
@@ -728,6 +728,12 @@ def balans(request):
 
 
 @login_required
+def ik_smtp(request):
+    return render(request, 'leden/ik_smtp.html',
+                  {'smtp_server': settings.MAILDOMAIN})
+
+
+@login_required
 def boekenlezers_name_check(request):
     if 'boekenlezers' not in request.user.cached_groups_names:
         raise PermissionDenied

--- a/kn/utils/giedo/postfix.py
+++ b/kn/utils/giedo/postfix.py
@@ -1,10 +1,8 @@
 import logging
 
 import protobufs.messages.daan_pb2 as daan_pb2
-from tarjan.tc import tc
 
 from django.conf import settings
-from django.utils import six
 
 import kn.leden.entities as Es
 from kn.leden.date import now
@@ -51,60 +49,11 @@ def generate_postfix_slm_map():
     # We generate the postfix "sender_login_maps".
     # This is used to decide by postfix whether a given user is allowed to
     # send e-mail as if it was coming from a particular e-mail address.
-    # It is a dictionary { <email address> : [ <allowed user>, ... ] }
-    tbl = dict()
-    dt_now = now()
-    # Get all users
-    ulut = dict()
     # We only allow members to send e-mail
-    for u in Es.by_name('leden').get_members():
-        ulut[u._id] = u
-        for name in u.names:
-            if str(name) not in tbl:
-                tbl[str(name)] = set()
-            tbl[str(name)].add(str(u.name))
-    # There are two kind of groups: groups whose members are allowed to
-    # send e-mail as if coming from the group itself and those where this
-    # is not allowed.  For convenience, lets call the first kind the
-    # impersonatable groups.
-    # Get all impersonatable groups and create a look-up-table for
-    # group membership
-    gs = list()
-    for g in Es.groups():
-        # TODO add a tag to force a group either impersonatable or not
-        if not g.got_mailman_list:
-            gs.append(g)
-    mrels = Es.query_relations(how=None, _with=gs, _from=dt_now, until=dt_now)
-    mlut = dict()
-    for g in gs:
-        mlut[g._id] = []
-    for mrel in mrels:
-        mlut[mrel['with']].append(mrel['who'])
-    # Flatten out group membership.  For instance: if Giedo is in Kasco
-    # and Kasco is in Boekenlezers, then Giedo is also in the Boekenlezers
-    # unix group.
-    # But first split the mlut graph into a impersonatable group
-    # and a non-group subgraph.
-    mlut_g = {}     # { <group> : <members that are impersonatable groups> }
-    mlut_u = {}    # { <group> : <members that are users> }
-    for g_id in mlut:
-        mlut_g[g_id] = [c for c in mlut[g_id] if c in mlut]
-        mlut_u[g_id] = [c for c in mlut[g_id] if c in ulut]
-    mlut_g_tc = tc(mlut_g)  # transitive closure
-    for g in gs:
-        to_consider = tuple(mlut_g_tc[g._id]) + (g._id,)
-        for sg_id in to_consider:
-            for u_id in mlut_u[sg_id]:
-                for name in g.names:
-                    if str(name) not in tbl:
-                        tbl[str(name)] = set()
-                    tbl[str(name)].add(str(ulut[u_id].name))
-    # Clean up tbl to return.
     ret = daan_pb2.PostfixMap()
-    for name, users in six.iteritems(tbl):
-        if not users:
-            continue
-        ret.map["%s@%s" % (name, settings.MAILDOMAIN)].values.extend(users)
+    for member in Es.by_name('leden').get_members():
+        for email in member.email_from_addresses:
+            ret.map[email].values.append(str(member.name))
     return ret
 
 # vim: et:sta:bs=2:sw=4:

--- a/salt/states/sankhara/initial-db.yaml
+++ b/salt/states/sankhara/initial-db.yaml
@@ -11,13 +11,13 @@ entities:
   names: ['!year-overrides']
   tags: [!id '4e6fcc85e60edf3dc0000000']
   types: [tag]
-- _id: !id '4e6fcc85e60edf3dc0000002'
+- _id: &virtual_id !id '4e6fcc85e60edf3dc0000002'
   humanNames:
   - {human: Virtuele groep, name: '!virtual-group'}
   names: ['!virtual-group']
   tags: [!id '4e6fcc85e60edf3dc0000000']
   types: [tag]
-- _id: !id '4e6fcc85e60edf3dc0000003'
+- _id: &sofa_brand_id !id '4e6fcc85e60edf3dc0000003'
   humanNames:
   - {human: Sofa merk, name: '!sofa-brand'}
   names: ['!sofa-brand']
@@ -349,7 +349,8 @@ entities:
 - humanNames:
   - {human: Docent Engels}
   types: [study]
-- description: Het bestuur
+- _id: &bestuur_id !id '4e6fcc85e60edf3dc0000067'
+  description: Het bestuur
   humanNames:
   - {genitive_prefix: van het, human: Bestuur, name: bestuur}
   names: [bestuur, bestuul, parkhangen, festivals]
@@ -752,6 +753,23 @@ entities:
   names: [disputen]
   tags: [!id '4e6fcc85e60edf3dc0000086']
   types: [tag]
+- humanNames:
+  - {human: 'Secretaris'}
+  _id: &brand_secretaris_id !id '4e6fcc85e60edf3dc0000bcd'
+  names: []
+  sofa_suffix: 'secretaris'
+  tags: [*sofa_brand_id]
+  types: [brand]
+- humanNames:
+  - human: 'Bestuur Secretaris'
+    name: 'bestuur-secretaris'
+  names: ['bestuur-secretaris', 'secretaris', 'penvoerder', 'abactis']
+  tags: [*virtual_id]
+  virtual:
+    how: *brand_secretaris_id
+    with: *bestuur_id
+    type: 'sofa'
+  types: [group, tag]
 
 - _id: &test_id !id '4e6fcc85e60edf3dc00001d4'
   address:


### PR DESCRIPTION
Add a special page with guidance how to add email settings.

This is the first step towards moving from using the user password in SMTP towards using a random token, to increase security and to drop the dependency on slapd.

---

Dit verandert vanuit welke adressen leden kunnen verzenden dus ik ga dit nog met het bestuur overleggen.