### PR TITLE
Sponsorpagina

### DIFF
--- a/kn/static/templates/static/sponsors.html
+++ b/kn/static/templates/static/sponsors.html
@@ -26,7 +26,7 @@ li img {
         {% blocktrans %}
         <h4>Studentenwegwijzer</h4>
         <p>
-        Alle nieuwtjes en de beste aanbiedingen voor studenten op één plek? Meer informatie over Karpe Noktem? Dit en meer vind je op het studentenplatform <a href="https:/www.studentenwegwijzer.nl">studentenwegwijzer.nl</a>.        </p>
+        Alle nieuwtjes en de beste aanbiedingen voor studenten op één plek? Meer informatie over Karpe Noktem? Dit en meer vind je op het studentenplatform <a href="https://www.studentenwegwijzer.nl">studentenwegwijzer.nl</a>.        </p>
         {% endblocktrans %}
       </li>
       <li>
@@ -35,7 +35,7 @@ li img {
         <h4>Club9</h4>
         <p>
          Heb je een (nieuw) matras nodig? Maar geen zin om oneindig te gaan proefliggen, of niet het geld voor de aanschaf? Huur een matras van Club 9!
-         Elke 5 jaar wordt je matras vervangen, en je betaalt per maand. Met de code 9R3G-FZM2-C9GN krijg je 10% korting     op het maandbedrag, en krijgt Karpe Noktem €100,-. Kijk voor meer informatie op <a href="https://www.club9-sleep    service.nl/?coupon=9R3G-FZM2-C9GN">Club9</a>.
+         Elke 5 jaar wordt je matras vervangen, en je betaalt per maand. Met de code 9R3G-FZM2-C9GN krijg je 10% korting     op het maandbedrag, en krijgt Karpe Noktem €100,-. Kijk voor meer informatie op <a href="https://www.club9-sleepservice.nl/">Club9</a>.
         </p>
         {% endblocktrans %}
       </li>

--- a/kn/static/templates/static/sponsors.html
+++ b/kn/static/templates/static/sponsors.html
@@ -35,7 +35,7 @@ li img {
         <h4>Club9</h4>
         <p>
          Heb je een (nieuw) matras nodig? Maar geen zin om oneindig te gaan proefliggen, of niet het geld voor de aanschaf? Huur een matras van Club 9!
-         Elke 5 jaar wordt je matras vervangen, en je betaalt per maand. Met de code 9R3G-FZM2-C9GN krijg je 10% korting     op het maandbedrag, en krijgt Karpe Noktem €100,-. Kijk voor meer informatie op <a href="https://www.club9-sleepservice.nl/">Club9</a>.
+         Elke 5 jaar wordt je matras vervangen, en je betaalt per maand. Met de code 9R3G-FZM2-C9GN krijg je 10% korting     op het maandbedrag, en krijgt Karpe Noktem €100,-. Kijk voor meer informatie op <a href="https://www.club9-sleepservice.nl/?coupon=9R3G-FZM2-C9GN">Club9</a>.
         </p>
         {% endblocktrans %}
       </li>


### PR DESCRIPTION
Attempt to fix broken links because links were broken. One of them missed a backslash, the other had some extra whitespace.