### PR TITLE
Update welcome mail to reflect automatic nature

### DIFF
--- a/kn/leden/templates/leden/welcome.mail.html
+++ b/kn/leden/templates/leden/welcome.mail.html
@@ -23,9 +23,9 @@ Beste {{ first_name }},
 <p>Wij hebben de volgende gegevens van jouw inschrijfformulier
 overgenomen. Kun je controleren of deze kloppen?</p>
 
-<p>Bij voorbaat dank,</p>
+<p>Met geautomatiseerde groet,</p>
 
-<p>Bas van Wijk</p>
+<p>Het smoelenboek</p>
 {% endblocktrans %}
 
 


### PR DESCRIPTION
This email is often interpreted as manually sent, which is not the case. In addition, updating the name is often forgotten, such that the signed name no longer corresponds to the current secretary.